### PR TITLE
Add GitHub Pages deployment for landing site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "landing/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: landing
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that deploys the `landing/` directory to GitHub Pages
- Triggers on pushes to `main` that modify `landing/**` or the workflow itself
- Uses the official `actions/deploy-pages` action with proper permissions

## Setup required
After merging, enable GitHub Pages in repo settings:
1. Go to **Settings → Pages**
2. Set **Source** to **GitHub Actions**

The site will be available at `https://hanneshapke.github.io/yaak/`

## Test plan
- [ ] Merge and verify the workflow runs successfully
- [ ] Confirm the landing page is accessible at the GitHub Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)