### PR TITLE
Disable aarch64-linux build target in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,10 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
 
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
-            archive: tar.gz
+          # TODO: re-enable once cross-compilation OpenSSL issue is resolved
+          # - target: aarch64-unknown-linux-gnu
+          #   os: ubuntu-latest
+          #   archive: tar.gz
 
           - target: x86_64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary
- Comment out the `aarch64-unknown-linux-gnu` build matrix entry in `ci.yml`
- Cross-compilation fails due to OpenSSL linking issues that persist even with rustls-tls
- Other targets (x86_64-linux, macOS x86_64/aarch64, Windows) are unaffected

## Test plan
- [ ] Verify CI passes on tag push without the aarch64-linux target

🤖 Generated with [Claude Code](https://claude.com/claude-code)