### PR TITLE
Fix config file not found on macOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,15 +65,23 @@ struct Config {
 }
 
 fn load_config() -> Config {
-    let Some(config_dir) = dirs::config_dir() else {
-        return Config::default();
-    };
-    let config_path = config_dir.join("yaak").join("config.toml");
-    if let Ok(contents) = std::fs::read_to_string(&config_path) {
-        toml::from_str(&contents).unwrap_or_default()
-    } else {
-        Config::default()
+    let mut candidates = Vec::new();
+    // XDG-style ~/.config (works on all platforms)
+    if let Some(home) = dirs::home_dir() {
+        candidates.push(home.join(".config").join("yaak").join("config.toml"));
     }
+    // Platform-native config dir (e.g. ~/Library/Application Support on macOS)
+    if let Some(config_dir) = dirs::config_dir() {
+        candidates.push(config_dir.join("yaak").join("config.toml"));
+    }
+    for path in candidates {
+        if let Ok(contents) = std::fs::read_to_string(&path) {
+            if let Ok(config) = toml::from_str(&contents) {
+                return config;
+            }
+        }
+    }
+    Config::default()
 }
 
 fn resolve(cli: Option<String>, config: Option<String>, fallback: &str) -> String {


### PR DESCRIPTION
## Summary
- Check `~/.config/yaak/config.toml` (XDG-style) before the platform-native config dir
- On macOS, `dirs::config_dir()` returns `~/Library/Application Support`, but docs instruct users to use `~/.config/yaak/config.toml` — so the config was never found
- Both locations are now supported, with `~/.config` checked first

## Test plan
- [x] Place config at `~/.config/yaak/config.toml` on macOS and verify it's read
- [x] Place config at `~/Library/Application Support/yaak/config.toml` and verify it's read as fallback
- [x] Verify Linux (`~/.config`) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)