### PR TITLE
Detect OS and shell for better command generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -150,7 +150,7 @@ fn main() {
         messages: vec![
             Message {
                 role: "system".into(),
-                content: system_prompt.into(),
+                content: system_prompt,
             },
             Message {
                 role: "user".into(),


### PR DESCRIPTION
## Summary
- Inject the user's OS (`macos`, `linux`, `windows`) and shell (`zsh`, `bash`, etc.) into the LLM system prompt so it generates platform-appropriate commands
- Run commands in the user's actual shell (`$SHELL`) instead of hardcoding `bash`
- Fixes issue where the LLM generated GNU/Linux-specific flags (e.g. `find -printf`) on macOS

## Test plan
- [ ] Run `yaak find the 5 biggest pdf on this laptop` on macOS — should use `stat` or `du` instead of `-printf`
- [ ] Verify `$SHELL` is respected (e.g. zsh users get zsh execution)
- [ ] Verify fallback to `bash` when `$SHELL` is unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)