### PR TITLE
Bump version to 0.0.2 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] — 2026-04-05
+
+### Added
+- OS and shell detection injected into LLM system prompt for platform-appropriate commands
+- Config file lookup at `~/.config/yaak/config.toml` (XDG-style) with fallback to platform-native config dir
+
+### Changed
+- Commands now run in the user's actual shell (`$SHELL`) instead of hardcoded `bash`
+- Switched `reqwest` from `native-tls` to `rustls-tls` for easier cross-compilation
+
+### Fixed
+- Config file not found on macOS where `dirs::config_dir()` returns `~/Library/Application Support`
+- LLM generating GNU/Linux-specific flags (e.g. `find -printf`) on macOS
+
+---
+
 ## [0.0.1] — 2026-04-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.1.0"
+version = "0.0.2"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 


### PR DESCRIPTION
## Summary
- Bump version in `Cargo.toml` from `0.1.0` to `0.0.2`
- Add `0.0.2` entry to `CHANGELOG.md` covering: OS/shell detection in prompts, config path fix on macOS, rustls-tls switch, and shell-aware command execution

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify changelog renders correctly via `python3 scripts/build_changelog.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)