### PR TITLE
Block destructive commands from execution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -111,6 +111,46 @@ fn extract_command(raw: &str) -> String {
     trimmed.to_string()
 }
 
+/// Destructive command prefixes/patterns that should be blocked.
+const DESTRUCTIVE_COMMANDS: &[&str] = &[
+    "rm ",
+    "rm\t",
+    "rmdir ",
+    "mkfs",
+    "dd ",
+    "dd\t",
+    "> /dev/",
+    "chmod -R 000",
+    "chmod 000",
+    ":(){ :|:& };:",
+    "shred ",
+    "wipefs ",
+];
+
+/// Returns `Some(keyword)` if the command contains a destructive operation.
+fn detect_destructive(command: &str) -> Option<&'static str> {
+    // Normalise: check each segment separated by && ; | ||
+    for segment in command.split(['&', ';', '|']) {
+        let trimmed = segment.trim().trim_start_matches('!');
+        let trimmed = trimmed.trim();
+        for &pattern in DESTRUCTIVE_COMMANDS {
+            if trimmed.starts_with(pattern) || trimmed == pattern.trim() {
+                return Some(pattern.trim());
+            }
+        }
+        // Also catch "sudo rm ..." etc.
+        if let Some(after_sudo) = trimmed.strip_prefix("sudo ") {
+            let after_sudo = after_sudo.trim();
+            for &pattern in DESTRUCTIVE_COMMANDS {
+                if after_sudo.starts_with(pattern) || after_sudo == pattern.trim() {
+                    return Some(pattern.trim());
+                }
+            }
+        }
+    }
+    None
+}
+
 fn main() {
     let args = Args::parse();
     let config = load_config();
@@ -208,6 +248,16 @@ fn main() {
     // --- Display and confirm ---
     eprintln!("\r{}{}", "  Command: ".bold(), command.green().bold());
 
+    // --- Block destructive commands ---
+    if let Some(keyword) = detect_destructive(&command) {
+        eprintln!(
+            "{} Destructive command blocked: `{}` is not allowed.",
+            "blocked:".red().bold(),
+            keyword
+        );
+        std::process::exit(1);
+    }
+
     let should_run = args.yes
         || Confirm::new()
             .with_prompt("Execute?")
@@ -229,5 +279,42 @@ fn main() {
             eprintln!("{} Failed to execute: {}", "error:".red().bold(), e);
             std::process::exit(1);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_rm() {
+        assert!(detect_destructive("rm -rf /").is_some());
+        assert!(detect_destructive("rm file.txt").is_some());
+    }
+
+    #[test]
+    fn blocks_sudo_rm() {
+        assert!(detect_destructive("sudo rm -rf /").is_some());
+    }
+
+    #[test]
+    fn blocks_rm_in_chain() {
+        assert!(detect_destructive("echo hello && rm -rf /tmp").is_some());
+        assert!(detect_destructive("ls; rm foo").is_some());
+    }
+
+    #[test]
+    fn blocks_other_destructive() {
+        assert!(detect_destructive("dd if=/dev/zero of=/dev/sda").is_some());
+        assert!(detect_destructive("mkfs.ext4 /dev/sda1").is_some());
+        assert!(detect_destructive("shred /dev/sda").is_some());
+    }
+
+    #[test]
+    fn allows_safe_commands() {
+        assert!(detect_destructive("ls -la").is_none());
+        assert!(detect_destructive("cat file.txt").is_none());
+        assert!(detect_destructive("grep -r pattern .").is_none());
+        assert!(detect_destructive("echo remove").is_none());
     }
 }


### PR DESCRIPTION
Add a safety check that detects and blocks dangerous commands (rm, dd,
mkfs, shred, wipefs, etc.) before they are executed. The check inspects
each segment of piped/chained commands and also catches sudo variants.

https://claude.ai/code/session_01NW21PWS4CYDQ794tz9iQSs