### PR TITLE
Bump version to 0.0.3 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] — 2026-04-05
+
+### Added
+- Safety check that blocks destructive commands (`rm`, `dd`, `mkfs`, `shred`, `wipefs`, etc.) before execution
+- Detection of `sudo` variants of dangerous commands in piped and chained command sequences
+
+---
+
 ## [0.0.2] — 2026-04-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 


### PR DESCRIPTION
## Summary
- Bump version in `Cargo.toml` from `0.0.2` to `0.0.3`
- Add `0.0.3` entry to `CHANGELOG.md` covering the destructive command blocking feature from PR #9

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify changelog renders correctly via `python3 scripts/build_changelog.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)