### PR TITLE
Add package metadata for crates.io publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "yaak"
 version = "0.0.3"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
+license = "Apache-2.0"
+homepage = "https://hanneshapke.com/yaak"
+repository = "https://github.com/hanneshapke/yaak"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.3"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"
-homepage = "https://hanneshapke.com/yaak"
+homepage = "https://www.hanneshapke.com/yaak/"
 repository = "https://github.com/hanneshapke/yaak"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- Add `license = "Apache-2.0"`, `homepage`, and `repository` fields to `Cargo.toml`
- Required for `cargo publish` to crates.io

## Test plan
- [ ] Run `cargo publish --dry-run` to verify metadata is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)