### PR TITLE
Bump version to 0.0.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] — 2026-04-05
+
+### Added
+- Reverse/explain mode (`-r`/`--reverse`/`-e`/`--explain`) that takes a shell command and returns a detailed visual breakdown with per-token explanations, examples, and caution warnings
+- Package metadata (`license`, `homepage`, `repository`) in `Cargo.toml` for crates.io publishing
+
+---
+
 ## [0.0.3] — 2026-04-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version in `Cargo.toml` from `0.0.3` to `0.0.4`
- Add `0.0.4` entry to `CHANGELOG.md` covering the reverse/explain mode (#12) and package metadata (#11)

## Test plan
- [ ] Verify `cargo build` succeeds
- [ ] Verify changelog renders correctly via `python3 scripts/build_changelog.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)