### PR TITLE
Add crates.io publish job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,3 +209,92 @@ jobs:
             artifacts/**/*.tar.gz
             artifacts/**/*.zip
             SHA256SUMS.txt
+
+  # ──────────────────────────────────────────────
+  # Homebrew: update tap formula after release
+  # ──────────────────────────────────────────────
+  homebrew:
+    name: Update Homebrew tap
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version from tag
+        id: version
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Download macOS release tarballs and compute SHA256
+        id: sha
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.tag }}"
+          BASE_URL="https://github.com/hanneshapke/yaak/releases/download/${VERSION}"
+
+          curl -fSL -o x86_64.tar.gz  "${BASE_URL}/yaak-${VERSION}-x86_64-apple-darwin.tar.gz"
+          curl -fSL -o aarch64.tar.gz "${BASE_URL}/yaak-${VERSION}-aarch64-apple-darwin.tar.gz"
+          curl -fSL -o linux_x86_64.tar.gz "${BASE_URL}/yaak-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+
+          echo "sha_mac_x86=$(sha256sum x86_64.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "sha_mac_arm=$(sha256sum aarch64.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
+          echo "sha_linux_x86=$(sha256sum linux_x86_64.tar.gz | awk '{print $1}')" >> $GITHUB_OUTPUT
+
+      - name: Generate Homebrew formula
+        shell: bash
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG="${{ steps.version.outputs.tag }}"
+          cat > yaak.rb <<FORMULA
+          class Yaak < Formula
+            desc "Translate natural language to bash commands using an OpenAI-compatible LLM"
+            homepage "https://www.hanneshapke.com/yaak/"
+            version "${VERSION}"
+            license "Apache-2.0"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/hanneshapke/yaak/releases/download/${TAG}/yaak-${TAG}-aarch64-apple-darwin.tar.gz"
+                sha256 "${{ steps.sha.outputs.sha_mac_arm }}"
+              else
+                url "https://github.com/hanneshapke/yaak/releases/download/${TAG}/yaak-${TAG}-x86_64-apple-darwin.tar.gz"
+                sha256 "${{ steps.sha.outputs.sha_mac_x86 }}"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.intel?
+                url "https://github.com/hanneshapke/yaak/releases/download/${TAG}/yaak-${TAG}-x86_64-unknown-linux-gnu.tar.gz"
+                sha256 "${{ steps.sha.outputs.sha_linux_x86 }}"
+              end
+            end
+
+            def install
+              bin.install "yaak"
+            end
+
+            test do
+              assert_match "yaak", shell_output("#{bin}/yaak --version")
+            end
+          end
+          FORMULA
+          # Remove leading whitespace from heredoc
+          sed -i 's/^          //' yaak.rb
+          cat yaak.rb
+
+      - name: Push formula to Homebrew tap
+        uses: dmnemec/copy_file_to_another_repo_action@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        with:
+          source_file: yaak.rb
+          destination_repo: hanneshapke/homebrew-yaak
+          destination_folder: Formula
+          destination_branch: main
+          user_email: github-actions[bot]@users.noreply.github.com
+          user_name: github-actions[bot]
+          commit_message: "Update yaak formula to ${{ steps.version.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,33 @@ jobs:
         run: cargo test --all-features --verbose
 
   # ──────────────────────────────────────────────
+  # Publish: push crate to crates.io
+  # ──────────────────────────────────────────────
+  publish:
+    name: Publish to crates.io
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify version matches tag
+        shell: bash
+        run: |
+          CARGO_VERSION="v$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')"
+          TAG_VERSION="${GITHUB_REF#refs/tags/}"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Cargo.toml version ($CARGO_VERSION) does not match tag ($TAG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to crates.io
+        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # ──────────────────────────────────────────────
   # Build: cross-platform release binaries
   # ──────────────────────────────────────────────
   build:


### PR DESCRIPTION
Adds a new `publish` job that runs on tag pushes to publish the crate
to crates.io. Includes a version-tag consistency check to ensure the
Cargo.toml version matches the git tag before publishing.

Requires a CARGO_REGISTRY_TOKEN secret to be configured in the repo.

https://claude.ai/code/session_011jGMsgnuB5rZib9TSLXo4R