### PR TITLE
Bump version to 0.0.5 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] — 2026-04-05
+
+### Added
+- Native Anthropic API support with auto-detection based on API base URL or model name
+- Automated crates.io publishing in CI on tag push, with version-tag consistency check
+
+### Fixed
+- Landing page GitHub links now point to the correct `hanneshapke/yaak` repository
+
+---
+
 ## [0.0.4] — 2026-04-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version in `Cargo.toml` from `0.0.4` to `0.0.5`
- Add `0.0.5` entry to `CHANGELOG.md` covering native Anthropic API support (#15), CI crates.io publishing (#16), and landing page link fix (#14)

## Test plan
- [x] Verify `cargo build` succeeds
- [x] Verify changelog renders correctly via `python3 scripts/build_changelog.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)