### PR TITLE
Fix cargo publish in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,9 @@ jobs:
           fi
 
       - name: Publish to crates.io
-        run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --allow-dirty
 
   # ──────────────────────────────────────────────
   # Build: cross-platform release binaries


### PR DESCRIPTION
## Summary
- Use `CARGO_REGISTRY_TOKEN` env var instead of deprecated `--token` flag
- Add `--allow-dirty` to handle `Cargo.lock` changes during CI build

## Test plan
- [ ] Push a `v*` tag after merge and verify the publish job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)