### PR TITLE
Add interactive config wizard (--config / -c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,37 @@ Execute? [Y/n] y
 ## Install
 
 ```bash
-cargo install --path .
+# Homebrew (macOS/Linux)
+brew tap hanneshapke/yaak
+brew install yaak
+
+# Or via Cargo
+cargo install yaak
+```
+
+## Quick setup
+
+Run the interactive config wizard:
+
+```
+$ yaak --config
+yaak configuration wizard
+────────────────────────────────────────
+
+? Select your API provider:
+  1. OpenAI
+  2. Anthropic
+❯ 3. Ollama
+  4. Groq
+  5. Together AI
+  6. OpenRouter
+  7. LM Studio
+  8. vLLM
+  9. LocalAI
+
+? Select a model: gemma3:4b
+
+✓ Config written to ~/.config/yaak/config.toml
 ```
 
 ## Configuration
@@ -20,12 +50,14 @@ yaak resolves settings in this priority order: **CLI flags → environment varia
 
 ### Config file
 
-Copy the example and edit it:
+Run `yaak --config` to generate the config interactively, or create it manually:
 
 ```bash
 mkdir -p ~/.config/yaak
 cp config.example.toml ~/.config/yaak/config.toml
 ```
+
+On macOS, yaak also checks `~/Library/Application Support/yaak/config.toml`.
 
 ### Environment variables
 
@@ -43,12 +75,15 @@ yaak <description of what you want to do>
 
 ### Options
 
-| Flag              | Short | Description                    |
-|-------------------|-------|--------------------------------|
-| `--api-base URL`  | `-u`  | API base URL                   |
-| `--api-key KEY`   | `-k`  | API key                        |
-| `--model NAME`    | `-m`  | Model name                     |
-| `--yes`           | `-y`  | Skip confirmation prompt       |
+| Flag              | Short | Description                              |
+|-------------------|-------|------------------------------------------|
+| `--config`        | `-c`  | Interactive configuration wizard         |
+| `--api-base URL`  | `-u`  | API base URL                             |
+| `--api-key KEY`   | `-k`  | API key                                  |
+| `--model NAME`    | `-m`  | Model name                               |
+| `--yes`           | `-y`  | Skip confirmation prompt                 |
+| `--reverse`       | `-r`  | Explain a command instead of generating  |
+| `--explain`       | `-e`  | Alias for --reverse                      |
 
 ### Examples
 
@@ -61,7 +96,14 @@ yaak -u http://localhost:11434/v1 -m llama3 show disk usage by directory
 
 # Pipe-friendly (skip confirmation)
 yaak -y count lines of code in src/
+
+# Explain a command
+yaak --explain 'find . -name "*.log" -mtime +30 -delete'
 ```
+
+### Safety
+
+yaak blocks destructive commands (`rm`, `dd`, `mkfs`, `shred`, etc.) from being executed, including `sudo` variants and piped/chained sequences.
 
 ## Compatible providers
 
@@ -78,9 +120,13 @@ yaak -u https://api.anthropic.com/v1 -k sk-ant-... find all large log files
 **OpenAI-compatible** (`/v1/chat/completions`):
 
 - **OpenAI** — `https://api.openai.com/v1`
-- **Ollama** — `http://localhost:11434/v1` (no key needed, use `-k none`)
+- **Ollama** — `http://localhost:11434/v1` (no key needed)
+- **Groq** — `https://api.groq.com/openai/v1`
 - **Together AI** — `https://api.together.xyz/v1`
 - **OpenRouter** — `https://openrouter.ai/api/v1`
-- **Groq** — `https://api.groq.com/openai/v1`
 - **LM Studio** — `http://localhost:1234/v1`
 - **vLLM / LocalAI** — your local URL
+
+## License
+
+Apache-2.0

--- a/landing/index.html
+++ b/landing/index.html
@@ -748,6 +748,27 @@ function copyCmd(el, cmd) {
 const demos = [
   {
     lines: [
+      { text: '<span class="t-green">$</span> <span class="t-bold">yaak --config</span>', delay: 400 },
+      { text: '<span class="t-bold">yaak configuration wizard</span>', delay: 300 },
+      { text: '<span class="t-dim">────────────────────────────────────────</span>', delay: 200 },
+      { text: '', delay: 100 },
+      { text: '<span class="t-amber">? Select your API provider:</span>', delay: 300 },
+      { text: '  <span class="t-dim">1.</span> OpenAI', delay: 100 },
+      { text: '  <span class="t-dim">2.</span> Anthropic', delay: 100 },
+      { text: '<span class="t-green">❯ 3.</span> <span class="t-bold">Ollama</span>', delay: 100 },
+      { text: '  <span class="t-dim">4.</span> Groq', delay: 100 },
+      { text: '', delay: 400 },
+      { text: '<span class="t-amber">? Select a model:</span> <span class="t-green">gemma3:4b</span>', delay: 500 },
+      { text: '', delay: 200 },
+      { text: '<span class="t-dim">────────────────────────────────────────</span>', delay: 200 },
+      { text: '<span class="t-green">✓</span> <span class="t-bold">Config written to ~/.config/yaak/config.toml</span>', delay: 400 },
+      { text: '  <span class="t-dim">Provider:</span> <span class="t-bold">Ollama</span>    <span class="t-dim">Model:</span> <span class="t-bold">gemma3:4b</span>', delay: 300 },
+      { text: '', delay: 200 },
+      { text: '<span class="t-green">You\'re all set! Try: yaak list files in current directory</span>', delay: 400 },
+    ]
+  },
+  {
+    lines: [
       { text: '<span class="t-green">$</span> <span class="t-bold">yaak</span> <span class="t-dim">compress all png files in this directory</span>', delay: 300 },
       { text: '<span class="t-dim">Thinking...</span>', delay: 500, replace: true },
       { text: '<span class="t-dim">  Command:</span> <span class="t-green">find . -maxdepth 1 -name "*.png" -exec pngquant --force --ext .png {} \\;</span>', delay: 900 },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use colored::Colorize;
-use dialoguer::Confirm;
+use dialoguer::{Confirm, Input, Password, Select};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::process::Command;
@@ -10,8 +10,12 @@ use std::process::Command;
 #[command(name = "yaak", version, about)]
 struct Args {
     /// The natural language description of the command you want
-    #[arg(trailing_var_arg = true, required = true)]
+    #[arg(trailing_var_arg = true)]
     description: Vec<String>,
+
+    /// Interactive configuration wizard — set up your config file
+    #[arg(short = 'c', long, exclusive = true)]
+    config: bool,
 
     /// API base URL (overrides YAAK_API_BASE / config)
     #[arg(short = 'u', long, env = "YAAK_API_BASE")]
@@ -188,8 +192,258 @@ fn detect_destructive(command: &str) -> Option<&'static str> {
     None
 }
 
+struct Provider {
+    name: &'static str,
+    api_base: &'static str,
+    needs_api_key: bool,
+    suggested_models: &'static [&'static str],
+}
+
+const PROVIDERS: &[Provider] = &[
+    Provider {
+        name: "OpenAI",
+        api_base: "https://api.openai.com/v1",
+        needs_api_key: true,
+        suggested_models: &["gpt-4o-mini", "gpt-4o", "gpt-4.1-mini", "gpt-4.1-nano"],
+    },
+    Provider {
+        name: "Anthropic",
+        api_base: "https://api.anthropic.com/v1",
+        needs_api_key: true,
+        suggested_models: &["claude-sonnet-4-6", "claude-haiku-4-5-20251001", "claude-opus-4-6"],
+    },
+    Provider {
+        name: "Ollama",
+        api_base: "http://localhost:11434/v1",
+        needs_api_key: false,
+        suggested_models: &["qwen3.5", "gemma3:4b", "llama3.2", "mistral"],
+    },
+    Provider {
+        name: "Groq",
+        api_base: "https://api.groq.com/openai/v1",
+        needs_api_key: true,
+        suggested_models: &["llama-3.3-70b-versatile", "gemma2-9b-it", "mixtral-8x7b-32768"],
+    },
+    Provider {
+        name: "Together AI",
+        api_base: "https://api.together.xyz/v1",
+        needs_api_key: true,
+        suggested_models: &["meta-llama/Llama-3-70b-chat-hf", "mistralai/Mixtral-8x7B-Instruct-v0.1"],
+    },
+    Provider {
+        name: "OpenRouter",
+        api_base: "https://openrouter.ai/api/v1",
+        needs_api_key: true,
+        suggested_models: &["openai/gpt-4o-mini", "anthropic/claude-sonnet-4-6", "meta-llama/llama-3-70b-instruct"],
+    },
+    Provider {
+        name: "LM Studio",
+        api_base: "http://localhost:1234/v1",
+        needs_api_key: false,
+        suggested_models: &["qwen3.5", "gemma3:4b"],
+    },
+    Provider {
+        name: "vLLM",
+        api_base: "http://localhost:8000/v1",
+        needs_api_key: false,
+        suggested_models: &["meta-llama/Llama-3-8b-chat-hf"],
+    },
+    Provider {
+        name: "LocalAI",
+        api_base: "http://localhost:8080/v1",
+        needs_api_key: false,
+        suggested_models: &["gpt-4o-mini"],
+    },
+];
+
+fn config_path() -> std::path::PathBuf {
+    if let Some(home) = dirs::home_dir() {
+        let xdg_path = home.join(".config").join("yaak").join("config.toml");
+        if xdg_path.exists() {
+            return xdg_path;
+        }
+    }
+    if let Some(config_dir) = dirs::config_dir() {
+        let native_path = config_dir.join("yaak").join("config.toml");
+        if native_path.exists() {
+            return native_path;
+        }
+    }
+    // Default: prefer ~/.config on Unix, platform-native elsewhere
+    if cfg!(unix) {
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".config")
+            .join("yaak")
+            .join("config.toml")
+    } else {
+        dirs::config_dir()
+            .unwrap_or_default()
+            .join("yaak")
+            .join("config.toml")
+    }
+}
+
+fn run_config_wizard() {
+    eprintln!("{}", "yaak configuration wizard".bold());
+    eprintln!("{}", "─".repeat(40).dimmed());
+    eprintln!();
+
+    // 1. Select provider
+    let provider_names: Vec<&str> = PROVIDERS.iter().map(|p| p.name).collect();
+    let provider_idx = Select::new()
+        .with_prompt("Select your API provider")
+        .items(&provider_names)
+        .default(0)
+        .interact()
+        .unwrap_or_else(|_| {
+            eprintln!("{}", "Aborted.".dimmed());
+            std::process::exit(0);
+        });
+
+    let provider = &PROVIDERS[provider_idx];
+    eprintln!();
+
+    // 2. Select model
+    let mut model_options: Vec<String> = provider
+        .suggested_models
+        .iter()
+        .map(|m| m.to_string())
+        .collect();
+    model_options.push("Enter custom model name".to_string());
+
+    let model_idx = Select::new()
+        .with_prompt("Select a model")
+        .items(&model_options)
+        .default(0)
+        .interact()
+        .unwrap_or_else(|_| {
+            eprintln!("{}", "Aborted.".dimmed());
+            std::process::exit(0);
+        });
+
+    let model = if model_idx == model_options.len() - 1 {
+        Input::<String>::new()
+            .with_prompt("Enter model name")
+            .interact_text()
+            .unwrap_or_else(|_| {
+                eprintln!("{}", "Aborted.".dimmed());
+                std::process::exit(0);
+            })
+    } else {
+        model_options[model_idx].clone()
+    };
+    eprintln!();
+
+    // 3. API key (if needed)
+    let api_key = if provider.needs_api_key {
+        let key = Password::new()
+            .with_prompt("Enter your API key")
+            .interact()
+            .unwrap_or_else(|_| {
+                eprintln!("{}", "Aborted.".dimmed());
+                std::process::exit(0);
+            });
+        if key.is_empty() {
+            eprintln!(
+                "{} API key is required for {}",
+                "warning:".yellow().bold(),
+                provider.name
+            );
+            std::process::exit(1);
+        }
+        eprintln!();
+        Some(key)
+    } else {
+        None
+    };
+
+    // Build config TOML
+    let mut config_content = String::new();
+    config_content.push_str("# yaak configuration — generated by `yaak --config`\n\n");
+    config_content.push_str(&format!("api_base = \"{}\"\n", provider.api_base));
+    if let Some(key) = &api_key {
+        config_content.push_str(&format!("api_key = \"{}\"\n", key));
+    }
+    config_content.push_str(&format!("model = \"{}\"\n", model));
+
+    // Write config file
+    let path = config_path();
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!(
+                "{} Failed to create config directory: {}",
+                "error:".red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+    }
+
+    // Warn if overwriting
+    if path.exists() {
+        let overwrite = Confirm::new()
+            .with_prompt(format!(
+                "Config already exists at {}. Overwrite?",
+                path.display()
+            ))
+            .default(false)
+            .interact()
+            .unwrap_or(false);
+        if !overwrite {
+            eprintln!("{}", "Aborted.".dimmed());
+            std::process::exit(0);
+        }
+    }
+
+    if let Err(e) = std::fs::write(&path, &config_content) {
+        eprintln!(
+            "{} Failed to write config: {}",
+            "error:".red().bold(),
+            e
+        );
+        std::process::exit(1);
+    }
+
+    eprintln!("{}", "─".repeat(40).dimmed());
+    eprintln!(
+        "{} Config written to {}",
+        "✓".green().bold(),
+        path.display().to_string().bold()
+    );
+    eprintln!(
+        "  {} {}",
+        "Provider:".dimmed(),
+        provider.name.bold()
+    );
+    eprintln!("  {} {}", "Model:".dimmed(), model.bold());
+    if api_key.is_some() {
+        eprintln!("  {} {}", "API key:".dimmed(), "••••••••".dimmed());
+    }
+    eprintln!();
+    eprintln!(
+        "{}",
+        "You're all set! Try: yaak list files in current directory"
+            .green()
+    );
+}
+
 fn main() {
     let args = Args::parse();
+
+    if args.config {
+        run_config_wizard();
+        std::process::exit(0);
+    }
+
+    if args.description.is_empty() {
+        eprintln!(
+            "{} No description provided. Run `yaak --help` for usage or `yaak --config` to set up.",
+            "error:".red().bold()
+        );
+        std::process::exit(1);
+    }
+
     let config = load_config();
 
     let api_base = resolve(args.api_base, config.api_base, "https://api.openai.com/v1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,11 @@ const PROVIDERS: &[Provider] = &[
         name: "Anthropic",
         api_base: "https://api.anthropic.com/v1",
         needs_api_key: true,
-        suggested_models: &["claude-sonnet-4-6", "claude-haiku-4-5-20251001", "claude-opus-4-6"],
+        suggested_models: &[
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5-20251001",
+            "claude-opus-4-6",
+        ],
     },
     Provider {
         name: "Ollama",
@@ -222,19 +226,30 @@ const PROVIDERS: &[Provider] = &[
         name: "Groq",
         api_base: "https://api.groq.com/openai/v1",
         needs_api_key: true,
-        suggested_models: &["llama-3.3-70b-versatile", "gemma2-9b-it", "mixtral-8x7b-32768"],
+        suggested_models: &[
+            "llama-3.3-70b-versatile",
+            "gemma2-9b-it",
+            "mixtral-8x7b-32768",
+        ],
     },
     Provider {
         name: "Together AI",
         api_base: "https://api.together.xyz/v1",
         needs_api_key: true,
-        suggested_models: &["meta-llama/Llama-3-70b-chat-hf", "mistralai/Mixtral-8x7B-Instruct-v0.1"],
+        suggested_models: &[
+            "meta-llama/Llama-3-70b-chat-hf",
+            "mistralai/Mixtral-8x7B-Instruct-v0.1",
+        ],
     },
     Provider {
         name: "OpenRouter",
         api_base: "https://openrouter.ai/api/v1",
         needs_api_key: true,
-        suggested_models: &["openai/gpt-4o-mini", "anthropic/claude-sonnet-4-6", "meta-llama/llama-3-70b-instruct"],
+        suggested_models: &[
+            "openai/gpt-4o-mini",
+            "anthropic/claude-sonnet-4-6",
+            "meta-llama/llama-3-70b-instruct",
+        ],
     },
     Provider {
         name: "LM Studio",
@@ -397,11 +412,7 @@ fn run_config_wizard() {
     }
 
     if let Err(e) = std::fs::write(&path, &config_content) {
-        eprintln!(
-            "{} Failed to write config: {}",
-            "error:".red().bold(),
-            e
-        );
+        eprintln!("{} Failed to write config: {}", "error:".red().bold(), e);
         std::process::exit(1);
     }
 
@@ -411,11 +422,7 @@ fn run_config_wizard() {
         "✓".green().bold(),
         path.display().to_string().bold()
     );
-    eprintln!(
-        "  {} {}",
-        "Provider:".dimmed(),
-        provider.name.bold()
-    );
+    eprintln!("  {} {}", "Provider:".dimmed(), provider.name.bold());
     eprintln!("  {} {}", "Model:".dimmed(), model.bold());
     if api_key.is_some() {
         eprintln!("  {} {}", "API key:".dimmed(), "••••••••".dimmed());
@@ -423,8 +430,7 @@ fn run_config_wizard() {
     eprintln!();
     eprintln!(
         "{}",
-        "You're all set! Try: yaak list files in current directory"
-            .green()
+        "You're all set! Try: yaak list files in current directory".green()
     );
 }
 


### PR DESCRIPTION
## Summary
- Add `-c` / `--config` flag that launches an interactive setup wizard
- Prompts the user to select a provider from a numbered list (OpenAI, Anthropic, Ollama, Groq, Together AI, OpenRouter, LM Studio, vLLM, LocalAI)
- Suggests model names per provider (local providers suggest qwen3.5, gemma3:4b)
- Securely prompts for API key (hidden input) only for providers that need one
- Writes config to the OS-appropriate location (`~/.config/yaak/config.toml` on Unix)
- Warns before overwriting an existing config file

## Test plan
- [ ] Run `yaak --config` and walk through the wizard for each provider type
- [ ] Verify config file is created at the correct location
- [ ] Verify API key is not displayed during input
- [ ] Verify `yaak --config` warns before overwriting existing config
- [ ] Verify `cargo clippy` and `cargo test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)