### PR TITLE
Bump version to 0.0.6 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] — 2026-04-06
+
+### Added
+- Interactive configuration wizard (`--config` / `-c`) with provider selection, model picker, and API key prompt
+- Homebrew install option on landing page (`brew tap hanneshapke/yaak && brew install yaak`)
+
+### Changed
+- Refactored `main.rs` into modules (`api`, `config`, `command`, `explain`, `wizard`) for maintainability
+
+---
+
 ## [0.0.5] — 2026-04-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaak"
-version = "0.0.4"
+version = "0.0.6"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version from 0.0.5 → 0.0.6 in `Cargo.toml`
- Add changelog entry for 0.0.6 covering PRs #19–#21: config wizard, Homebrew install on landing page, and module refactor

## Test plan
- [x] `cargo check` compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)