### PR TITLE
Fix terminal demo width for mobile viewports

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -509,6 +509,8 @@
     .hero-divider { display: none; }
     .demo-columns { grid-template-columns: 1fr; }
     .demo-aside { position: static; }
+    .terminal { width: 100%; }
+    .terminal-body { padding: 16px; font-size: 12px; height: 360px; }
     .section-header { grid-template-columns: 1fr; gap: 16px; }
     .section-number { font-size: 80px; letter-spacing: -4px; }
     .why-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
The fixed 640px terminal width overflows on narrow screens. Set width
to 100% at the 768px breakpoint and reduce padding/font-size/height
so the demo fits comfortably on mobile devices.

https://claude.ai/code/session_015NNVAhFj4xwPkNxTFFkjQV