### PR TITLE
Add yaak name explanation and fix mobile terminal width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# yaak
+# yaak — Yet Another AI for the Kommandozeile
 
 Translate natural language into bash commands using any OpenAI-compatible LLM.
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -509,6 +509,8 @@
     .hero-divider { display: none; }
     .demo-columns { grid-template-columns: 1fr; }
     .demo-aside { position: static; }
+    .terminal { width: 100%; }
+    .terminal-body { padding: 16px; font-size: 12px; height: 360px; }
     .section-header { grid-template-columns: 1fr; gap: 16px; }
     .section-number { font-size: 80px; letter-spacing: -4px; }
     .why-grid { grid-template-columns: 1fr; }

--- a/landing/index.html
+++ b/landing/index.html
@@ -548,7 +548,7 @@
     </h1>
     <div class="hero-row">
       <div class="hero-lede">
-        <strong>yaak</strong> is a tiny Rust CLI that translates plain English
+        <strong>yaak</strong> (<em>Yet Another AI for the Kommandozeile</em>) is a tiny Rust CLI that translates plain English
         into the right shell command — using Anthropic, OpenAI, or any compatible model you choose.
         Describe what you want, review the command, hit enter. That's it.
       </div>


### PR DESCRIPTION
## Summary
- Add the yaak abbreviation (*Yet Another AI for the Kommandozeile*) to the README heading and landing page hero section
- Fix the demo terminal width on mobile viewports: set `width: 100%` at the 768px breakpoint and reduce padding, font-size, and height for a better mobile experience

## Test plan
- [ ] Verify the README renders the abbreviation correctly on GitHub
- [ ] View the landing page on a mobile-width browser and confirm the terminal demo fits without overflow
- [ ] Confirm desktop layout is unchanged

https://claude.ai/code/session_015NNVAhFj4xwPkNxTFFkjQV