### PR TITLE
Add streaming output for LLM responses

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -7,6 +7,7 @@ pub struct ChatRequest {
     pub model: String,
     pub messages: Vec<Message>,
     pub temperature: f32,
+    pub stream: bool,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -15,16 +16,20 @@ pub struct Message {
     pub content: String,
 }
 
+// Non-streaming response structs (retained for tests)
+#[cfg(test)]
 #[derive(Deserialize)]
 pub struct ChatResponse {
     pub choices: Vec<Choice>,
 }
 
+#[cfg(test)]
 #[derive(Deserialize)]
 pub struct Choice {
     pub message: MessageContent,
 }
 
+#[cfg(test)]
 #[derive(Deserialize)]
 pub struct MessageContent {
     pub content: String,
@@ -39,13 +44,17 @@ pub struct AnthropicRequest {
     pub messages: Vec<Message>,
     pub max_tokens: u32,
     pub temperature: f32,
+    pub stream: bool,
 }
 
+// Non-streaming response structs (retained for tests)
+#[cfg(test)]
 #[derive(Deserialize)]
 pub struct AnthropicResponse {
     pub content: Vec<AnthropicContent>,
 }
 
+#[cfg(test)]
 #[derive(Deserialize)]
 pub struct AnthropicContent {
     pub text: String,
@@ -81,6 +90,7 @@ mod tests {
             }],
             max_tokens: 1024,
             temperature: 0.0,
+            stream: true,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "claude-sonnet-4-6");
@@ -123,6 +133,7 @@ mod tests {
                 },
             ],
             temperature: 0.0,
+            stream: true,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["model"], "gpt-4o-mini");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,10 @@ mod api;
 mod command;
 mod config;
 mod explain;
+mod streaming;
 mod wizard;
 
-use api::{AnthropicRequest, AnthropicResponse, ChatRequest, ChatResponse, Message};
+use api::{AnthropicRequest, ChatRequest, Message};
 use clap::Parser;
 use colored::Colorize;
 use command::{detect_destructive, extract_command};
@@ -12,6 +13,7 @@ use config::{load_config, resolve};
 use dialoguer::Confirm;
 use explain::render_explanation;
 use std::env;
+use std::io::Write;
 use std::process::Command;
 
 /// yaak — translate natural language into bash commands using an OpenAI-compatible LLM
@@ -125,13 +127,7 @@ fn main() {
         )
     };
 
-    // --- Call the LLM ---
-    if args.reverse {
-        eprint!("{}", "Explaining... ".dimmed());
-    } else {
-        eprint!("{}", "Thinking... ".dimmed());
-    }
-
+    // --- Call the LLM (streaming) ---
     let client = reqwest::blocking::Client::new();
 
     let response = if anthropic {
@@ -145,6 +141,7 @@ fn main() {
             }],
             max_tokens: 1024,
             temperature: 0.0,
+            stream: true,
         };
         client
             .post(&url)
@@ -168,6 +165,7 @@ fn main() {
                 },
             ],
             temperature: 0.0,
+            stream: true,
         };
         client
             .post(&url)
@@ -180,7 +178,7 @@ fn main() {
     let response = match response {
         Ok(r) => r,
         Err(e) => {
-            eprintln!("\n{} Failed to reach API: {}", "error:".red().bold(), e);
+            eprintln!("{} Failed to reach API: {}", "error:".red().bold(), e);
             std::process::exit(1);
         }
     };
@@ -189,7 +187,7 @@ fn main() {
         let status = response.status();
         let body = response.text().unwrap_or_default();
         eprintln!(
-            "\n{} API returned {} — {}",
+            "{} API returned {} — {}",
             "error:".red().bold(),
             status,
             body
@@ -197,37 +195,41 @@ fn main() {
         std::process::exit(1);
     }
 
-    let raw_content = if anthropic {
-        let resp: AnthropicResponse = match response.json() {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!(
-                    "\n{} Failed to parse response: {}",
-                    "error:".red().bold(),
-                    e
-                );
-                std::process::exit(1);
+    // --- Stream and collect tokens ---
+    let raw_content = if args.reverse {
+        // Explain mode: stream tokens to stderr for real-time feedback
+        let mut collected = String::new();
+        let mut first_token = true;
+        streaming::stream_tokens(response, anthropic, |token| {
+            if first_token {
+                // Clear the line and print header before first token
+                eprint!("\r\x1b[K");
+                first_token = false;
             }
-        };
-        resp.content[0].text.clone()
+            eprint!("{}", token);
+            let _ = std::io::stderr().flush();
+            collected.push_str(token);
+        });
+        eprintln!();
+        collected
     } else {
-        let resp: ChatResponse = match response.json() {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!(
-                    "\n{} Failed to parse response: {}",
-                    "error:".red().bold(),
-                    e
-                );
-                std::process::exit(1);
+        // Generate mode: collect tokens silently, show a dot progress indicator
+        eprint!("{}", "Thinking ".dimmed());
+        let mut collected = String::new();
+        let mut token_count = 0usize;
+        streaming::stream_tokens(response, anthropic, |token| {
+            collected.push_str(token);
+            token_count += 1;
+            if token_count.is_multiple_of(4) {
+                eprint!("{}", ".".dimmed());
+                let _ = std::io::stderr().flush();
             }
-        };
-        resp.choices[0].message.content.clone()
+        });
+        eprint!("\r\x1b[K"); // clear progress line
+        collected
     };
 
     if args.reverse {
-        // --- Reverse / Explain mode ---
-        eprintln!("\r"); // clear "Thinking..."
         render_explanation(&description, &raw_content);
         std::process::exit(0);
     }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,0 +1,152 @@
+use serde::Deserialize;
+use std::io::{BufRead, BufReader, Read};
+
+/// Extract text tokens from an SSE stream (Server-Sent Events).
+/// Works with both OpenAI-compatible and Anthropic streaming formats.
+/// Calls `on_token` for each text delta received.
+pub fn stream_tokens<R: Read>(reader: R, anthropic: bool, mut on_token: impl FnMut(&str)) {
+    let buf = BufReader::new(reader);
+
+    for line in buf.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+
+        // OpenAI signals end with [DONE]
+        if data == "[DONE]" {
+            break;
+        }
+
+        if anthropic {
+            if let Some(token) = parse_anthropic_delta(data) {
+                on_token(&token);
+            }
+        } else if let Some(token) = parse_openai_delta(data) {
+            on_token(&token);
+        }
+    }
+}
+
+// --- OpenAI streaming delta ---
+
+#[derive(Deserialize)]
+struct OpenAiChunk {
+    choices: Vec<OpenAiChunkChoice>,
+}
+
+#[derive(Deserialize)]
+struct OpenAiChunkChoice {
+    delta: OpenAiDelta,
+}
+
+#[derive(Deserialize)]
+struct OpenAiDelta {
+    content: Option<String>,
+}
+
+fn parse_openai_delta(data: &str) -> Option<String> {
+    let chunk: OpenAiChunk = serde_json::from_str(data).ok()?;
+    chunk.choices.first()?.delta.content.clone()
+}
+
+// --- Anthropic streaming delta ---
+
+#[derive(Deserialize)]
+struct AnthropicEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    delta: Option<AnthropicDelta>,
+}
+
+#[derive(Deserialize)]
+struct AnthropicDelta {
+    #[serde(rename = "type")]
+    delta_type: Option<String>,
+    text: Option<String>,
+}
+
+fn parse_anthropic_delta(data: &str) -> Option<String> {
+    let event: AnthropicEvent = serde_json::from_str(data).ok()?;
+    if event.event_type != "content_block_delta" {
+        return None;
+    }
+    let delta = event.delta?;
+    if delta.delta_type.as_deref() != Some("text_delta") {
+        return None;
+    }
+    delta.text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_openai_delta_extracts_content() {
+        let data = r#"{"id":"x","choices":[{"index":0,"delta":{"content":"hello"}}]}"#;
+        assert_eq!(parse_openai_delta(data), Some("hello".into()));
+    }
+
+    #[test]
+    fn parse_openai_delta_empty_delta() {
+        // First chunk often has role but no content
+        let data = r#"{"id":"x","choices":[{"index":0,"delta":{"role":"assistant"}}]}"#;
+        assert_eq!(parse_openai_delta(data), None);
+    }
+
+    #[test]
+    fn parse_anthropic_delta_extracts_text() {
+        let data = r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}"#;
+        assert_eq!(parse_anthropic_delta(data), Some("world".into()));
+    }
+
+    #[test]
+    fn parse_anthropic_delta_ignores_other_events() {
+        let data = r#"{"type":"message_start","message":{"id":"x"}}"#;
+        assert_eq!(parse_anthropic_delta(data), None);
+    }
+
+    #[test]
+    fn stream_tokens_openai_format() {
+        let input = "\
+data: {\"id\":\"x\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"}}]}\n\
+\n\
+data: {\"id\":\"x\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"ls\"}}]}\n\
+\n\
+data: {\"id\":\"x\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" -la\"}}]}\n\
+\n\
+data: [DONE]\n";
+
+        let mut collected = String::new();
+        stream_tokens(input.as_bytes(), false, |t| collected.push_str(t));
+        assert_eq!(collected, "ls -la");
+    }
+
+    #[test]
+    fn stream_tokens_anthropic_format() {
+        let input = "\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"x\"}}\n\
+\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"find\"}}\n\
+\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\" . -name\"}}\n\
+\n\
+data: {\"type\":\"message_stop\"}\n";
+
+        let mut collected = String::new();
+        stream_tokens(input.as_bytes(), true, |t| collected.push_str(t));
+        assert_eq!(collected, "find . -name");
+    }
+
+    #[test]
+    fn stream_tokens_handles_empty_input() {
+        let mut collected = String::new();
+        stream_tokens("".as_bytes(), false, |t| collected.push_str(t));
+        assert_eq!(collected, "");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #28

- Replaces blocking JSON responses with Server-Sent Events (SSE) streaming for both OpenAI-compatible and Anthropic APIs
- **Explain mode**: tokens stream to stderr in real-time as they arrive, giving immediate feedback instead of a frozen "Explaining..." message
- **Generate mode**: shows a dot-based progress indicator (`Thinking ...`) while collecting tokens, then displays the final command
- New `streaming` module handles SSE line parsing with dedicated delta extractors for both provider formats
- Requests now send `stream: true` to both OpenAI and Anthropic endpoints
- Non-streaming response structs (`ChatResponse`, `AnthropicResponse`) moved behind `#[cfg(test)]`

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test` — all 31 tests pass (7 new streaming tests)
- [ ] Manual: `yaak list files` — verify dot progress and command display
- [ ] Manual: `yaak --explain "ls -la"` — verify real-time token streaming
- [ ] Manual: test with Anthropic provider (different SSE format)
- [ ] Manual: test with local Ollama (OpenAI-compatible streaming)

https://claude.ai/code/session_01MCbxanbKVuV9mc6NkRN9eG