### PR TITLE
Fix license in landing page footer to Apache-2.0

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -736,7 +736,7 @@
 
 <!-- FOOTER -->
 <footer>
-  <span>yaak &mdash; open source, MIT licensed</span>
+  <span>yaak &mdash; open source, Apache-2.0 licensed</span>
   <span>Built with Rust &amp; <a href="#">your favorite LLM</a></span>
 </footer>
 


### PR DESCRIPTION
## Summary
- Fix landing page footer: "MIT licensed" → "Apache-2.0 licensed" to match the actual project license

## Test plan
- [ ] Verify footer text on landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)