### PR TITLE
Skip API key requirement for local providers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -168,7 +168,8 @@ fn main() {
     };
     let model = resolve(args.model, config.model, default_model);
 
-    if api_key.is_empty() {
+    let needs_api_key = !api_base.contains("localhost") && !api_base.contains("127.0.0.1");
+    if needs_api_key && api_key.is_empty() {
         eprintln!(
             "{} No API key found. Set YAAK_API_KEY, pass --api-key, or add it to ~/.config/yaak/config.toml",
             "error:".red().bold()


### PR DESCRIPTION
## Summary
- Skip the API key check when `api_base` points to `localhost` or `127.0.0.1`
- Fixes Ollama, LM Studio, vLLM, and LocalAI usage without needing a dummy API key
- Remote providers (OpenAI, Anthropic, Groq, etc.) still require a key as before

## Test plan
- [ ] `yaak --api-base http://localhost:11434/v1 --model llama3.2 list files` works without API key
- [ ] `yaak list files` with a remote provider and no API key still shows the error message
- [ ] All 48 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)