### PR TITLE
Add Doubleword as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ yaak -u https://api.anthropic.com/v1 -k sk-ant-... find all large log files
 - **Groq** — `https://api.groq.com/openai/v1`
 - **Together AI** — `https://api.together.xyz/v1`
 - **OpenRouter** — `https://openrouter.ai/api/v1`
+- **Doubleword** — `https://api.doubleword.ai/v1`
 - **LM Studio** — `http://localhost:1234/v1`
 - **vLLM / LocalAI** — your local URL
 

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -476,6 +476,7 @@
             <tr><td>Groq</td><td><code>https://api.groq.com/openai/v1</code></td><td>Yes</td></tr>
             <tr><td>Together AI</td><td><code>https://api.together.xyz/v1</code></td><td>Yes</td></tr>
             <tr><td>OpenRouter</td><td><code>https://openrouter.ai/api/v1</code></td><td>Yes</td></tr>
+            <tr><td>Doubleword</td><td><code>https://api.doubleword.ai/v1</code></td><td>Yes</td></tr>
             <tr><td>LM Studio</td><td><code>http://localhost:1234/v1</code></td><td>No</td></tr>
             <tr><td>vLLM</td><td><code>http://localhost:8000/v1</code></td><td>No</td></tr>
             <tr><td>LocalAI</td><td><code>http://localhost:8080/v1</code></td><td>No</td></tr>

--- a/landing/index.html
+++ b/landing/index.html
@@ -645,7 +645,7 @@
       <div class="why-cell">
         <span class="cell-number">iii</span>
         <h3>Bring your own model</h3>
-        <p>Works with Anthropic, OpenAI, Ollama, Groq, Together, OpenRouter, or any local server. You own the key and pick the model.</p>
+        <p>Works with Anthropic, OpenAI, Ollama, Groq, Together, OpenRouter, Doubleword, or any local server. You own the key and pick the model.</p>
       </div>
       <div class="why-cell">
         <span class="cell-number">iv</span>
@@ -740,6 +740,7 @@
       <span class="provider-tag">Groq</span>
       <span class="provider-tag">Together AI</span>
       <span class="provider-tag">OpenRouter</span>
+      <span class="provider-tag">Doubleword</span>
       <span class="provider-tag">vLLM</span>
       <span class="provider-tag">LM Studio</span>
       <span class="provider-tag">LocalAI</span>

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -63,6 +63,16 @@ pub const PROVIDERS: &[Provider] = &[
         ],
     },
     Provider {
+        name: "Doubleword",
+        api_base: "https://api.doubleword.ai/v1",
+        needs_api_key: true,
+        suggested_models: &[
+            "Qwen/Qwen3.5-35B-A3B-FP8",
+            "Qwen/Qwen3.5-9B",
+            "Qwen/Qwen3-14B-FP8",
+        ],
+    },
+    Provider {
         name: "LM Studio",
         api_base: "http://localhost:1234/v1",
         needs_api_key: false,


### PR DESCRIPTION
## Summary
- Add [Doubleword](https://docs.doubleword.ai/inference-api/realtime-inference) as a provider in the config wizard (`src/wizard.rs`)
- API base: `https://api.doubleword.ai/v1` (OpenAI-compatible, requires API key)
- Suggested models: `Qwen/Qwen3.5-35B-A3B-FP8`, `Qwen/Qwen3.5-9B`, `Qwen/Qwen3-14B-FP8`
- Update README, landing page providers section, and docs page provider table

## Test plan
- [ ] `yaak --config` shows Doubleword in the provider list
- [ ] Selecting Doubleword shows the suggested models
- [ ] Landing page provider tags include Doubleword
- [ ] Docs page provider table includes Doubleword row
- [ ] All 48 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)