### PR TITLE
Bump v0.0.11 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] — 2026-04-07
+
+### Added
+- Doubleword as a provider (`https://api.doubleword.ai/v1`) with suggested models
+
+---
+
 ## [0.0.10] — 2026-04-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.0.10"
+version = "0.0.11"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version to 0.0.11 in `Cargo.toml`
- Add changelog entry for Doubleword provider (#71)

## Test plan
- [ ] `cargo check` passes
- [ ] Version in `Cargo.toml` matches changelog header

🤖 Generated with [Claude Code](https://claude.com/claude-code)