### PR TITLE
Add --update / -U flag for self-updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ yaak <description of what you want to do>
 | `--search KEYWORD`      | `-s`  | Search command history by keyword        |
 | `--language LANG`       | `-L`  | UI language: en, de, es, fr, pt, zh, ja, ko |
 | `--version`             | `-v`  | Print version number                     |
+| `--update`              | `-U`  | Update yaak to the latest version        |
 | `--feedback`            |       | Open the feedback page in your browser   |
 | `--completions SHELL`   |       | Generate shell completions (bash/zsh/fish)|
 

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -406,6 +406,7 @@
             <tr><td><code>--search</code></td><td><code>-s</code></td><td>Search command history by keyword</td></tr>
             <tr><td><code>--language</code></td><td><code>-L</code></td><td>UI language: en, de, es, fr, pt, zh, ja, ko</td></tr>
             <tr><td><code>--version</code></td><td><code>-v</code></td><td>Print version number</td></tr>
+            <tr><td><code>--update</code></td><td><code>-U</code></td><td>Update yaak to the latest version</td></tr>
             <tr><td><code>--feedback</code></td><td></td><td>Open the feedback page in your browser</td></tr>
             <tr><td><code>--completions</code></td><td></td><td>Generate shell completions (bash/zsh/fish)</td></tr>
             <tr><td><code>--limit</code></td><td></td><td>Number of history entries to show (default: 20)</td></tr>

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,10 @@ struct Args {
     /// Open the feedback page in your browser
     #[arg(long, exclusive = true)]
     feedback: bool,
+
+    /// Update yaak to the latest version
+    #[arg(short = 'U', long, exclusive = true)]
+    update: bool,
 }
 
 fn main() {
@@ -133,6 +137,11 @@ fn main() {
         );
         eprintln!("{} Opening feedback page...", "✓".green().bold());
         open_url(&url);
+        return;
+    }
+
+    if args.update {
+        self_update();
         return;
     }
 
@@ -667,6 +676,91 @@ fn open_url(url: &str) {
         command.arg(arg);
     }
     let _ = command.arg(url).spawn();
+}
+
+fn self_update() {
+    let current = env!("CARGO_PKG_VERSION");
+    eprintln!(
+        "{} Current version: {}",
+        "info:".bold(),
+        format!("v{}", current).dimmed()
+    );
+
+    // Check latest version via GitHub redirect
+    eprintln!("{} Checking for updates...", "info:".bold());
+    let output = Command::new("curl")
+        .args([
+            "-fsS",
+            "-o",
+            "/dev/null",
+            "-w",
+            "%{redirect_url}",
+            "https://github.com/hanneshapke/yaak/releases/latest",
+        ])
+        .output();
+
+    let latest = match output {
+        Ok(o) => {
+            let url = String::from_utf8_lossy(&o.stdout).to_string();
+            url.rsplit('/').next().unwrap_or("").to_string()
+        }
+        Err(e) => {
+            eprintln!(
+                "{} Failed to check for updates: {}",
+                "error:".red().bold(),
+                e
+            );
+            std::process::exit(1);
+        }
+    };
+
+    if latest.is_empty() {
+        eprintln!(
+            "{} Could not determine latest version",
+            "error:".red().bold()
+        );
+        std::process::exit(1);
+    }
+
+    let latest_trimmed = latest.trim_start_matches('v');
+    if latest_trimmed == current {
+        eprintln!(
+            "{} Already up to date ({})",
+            "✓".green().bold(),
+            format!("v{}", current).bold()
+        );
+        return;
+    }
+
+    eprintln!(
+        "{} Updating v{} → {}...",
+        "info:".bold(),
+        current,
+        latest.bold()
+    );
+
+    // Run the install script to perform the update
+    let status = Command::new("bash")
+        .args(["-c", "curl -fsSL https://getyaak.ai/install.sh | bash"])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {
+            eprintln!("{} Updated to {}", "✓".green().bold(), latest.bold());
+        }
+        Ok(s) => {
+            eprintln!(
+                "{} Update failed (exit code {})",
+                "error:".red().bold(),
+                s.code().unwrap_or(1)
+            );
+            std::process::exit(1);
+        }
+        Err(e) => {
+            eprintln!("{} Update failed: {}", "error:".red().bold(), e);
+            std::process::exit(1);
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add `--update` / `-U` flag that checks for the latest version and updates in place
- Compares current version against latest GitHub release tag
- If already up to date, prints a message and exits
- If update available, runs the install script (`curl | bash`) to download, verify, and install
- Add flag to README and docs flag tables

## How it works
```
$ yaak --update
info: Current version: v0.1.1
info: Checking for updates...
info: Updating v0.1.1 → v0.1.2...
  > Detected platform: Darwin arm64 (aarch64-apple-darwin)
  ...
✓ Updated to v0.1.2

$ yaak --update
info: Current version: v0.1.2
info: Checking for updates...
✓ Already up to date (v0.1.2)
```

## Test plan
- [ ] `yaak --update` when already on latest → prints "Already up to date"
- [ ] `yaak -U` works as short alias
- [ ] `cargo fmt --all -- --check` passes
- [ ] All 55 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)