### PR TITLE
Bump v0.1.2 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.2] — 2026-04-08
 
+### Added
+- `--update` / `-U` flag to self-update yaak to the latest version
+- `--feedback` flag to open a pre-filled GitHub Issue in your browser with version and platform info
+
 ### Changed
 - Cache mode now uses BM25 fuzzy matching — similar descriptions hit the cache even when wording differs
 - Updated landing page, docs, and README with BM25 cache details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] — 2026-04-08
+
+### Changed
+- Cache mode now uses BM25 fuzzy matching — similar descriptions hit the cache even when wording differs
+- Updated landing page, docs, and README with BM25 cache details
+
+---
+
 ## [0.1.1] — 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaak"
-version = "0.0.12"
+version = "0.1.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.2
- Add changelog entry for BM25 fuzzy cache matching and docs updates

## Test plan
- [ ] Verify `yaak --version` prints `0.1.2`
- [ ] Confirm changelog renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)