### PR TITLE
Fix Homebrew install to use fully qualified formula name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ $ yaak list all rust files larger than 1MB
 curl -fsSL https://getyaak.ai/install.sh | bash
 
 # Homebrew (macOS/Linux)
-brew tap hanneshapke/yaak
-brew install yaak
+brew install hanneshapke/yaak/yaak
 
 # Or via Cargo
 cargo install yaak

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -304,7 +304,7 @@
         </div>
         <h3>Homebrew (macOS / Linux)</h3>
         <div class="doc-code">
-          <span class="t-green">$</span> brew tap hanneshapke/yaak && brew install yaak
+          <span class="t-green">$</span> brew install hanneshapke/yaak/yaak
         </div>
         <h3>Cargo</h3>
         <div class="doc-code">

--- a/landing/index.html
+++ b/landing/index.html
@@ -610,8 +610,8 @@
           <button class="copy-btn">Copy</button>
         </div>
         <div class="install-label" style="margin-top: 12px;">Or via Homebrew</div>
-        <div class="install-cmd" onclick="copyCmd(this, 'brew tap hanneshapke/yaak && brew install yaak')">
-          <span><span class="prompt">$</span> brew tap hanneshapke/yaak && brew install yaak</span>
+        <div class="install-cmd" onclick="copyCmd(this, 'brew install hanneshapke/yaak/yaak')">
+          <span><span class="prompt">$</span> brew install hanneshapke/yaak/yaak</span>
           <button class="copy-btn">Copy</button>
         </div>
         <div style="font-size:12px; color:var(--ink-faint); font-family:'DM Mono',monospace; letter-spacing:0.5px;">
@@ -784,8 +784,8 @@
       </button>
       <div class="cta-alt">
         or via Homebrew:
-        <button class="cta-button cta-button--secondary" onclick="copyCmd(this, 'brew tap hanneshapke/yaak && brew install yaak')">
-          $ brew install yaak
+        <button class="cta-button cta-button--secondary" onclick="copyCmd(this, 'brew install hanneshapke/yaak/yaak')">
+          $ brew install hanneshapke/yaak/yaak
         </button>
       </div>
     </div>


### PR DESCRIPTION
The bare `brew install yaak` collides with an existing cask of the same
name, causing Homebrew to install a GUI .app to /Applications instead of
the CLI formula to /usr/local/bin. Using the fully qualified name
`hanneshapke/yaak/yaak` avoids the ambiguity, auto-taps the repo, and
ensures the CLI binary is installed correctly.

https://claude.ai/code/session_01EWTmaRRtUrN1CaWYFwCtnM