### PR TITLE
Fix i18n translations and bump to v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] — 2026-04-09
+
+### Fixed
+- Fix i18n translations showing raw key names instead of translated text by removing invalid `[_]` TOML section headers from locale files
+- Improve command label formatting — use a line break instead of leading spaces
+
+---
+
 ## [0.1.2] — 2026-04-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaak"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"

--- a/locales/de.toml
+++ b/locales/de.toml
@@ -1,6 +1,5 @@
 # German translations
 
-[_]
 # General
 aborted = "Abgebrochen."
 cached = "(zwischengespeichert)"
@@ -22,7 +21,7 @@ error_no_api_key = "Kein API-Schlüssel gefunden. Setze YAAK_API_KEY, nutze --ap
 prompt_execute = "Ausführen?"
 prompt_what_next = "Was nun?"
 prompt_refine = "Anfrage verfeinern"
-label_command = "  Befehl: "
+label_command = "\nBefehl: "
 label_thinking = "Denke nach "
 choice_execute = "Ausführen"
 choice_refine = "Verfeinern"

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -1,6 +1,5 @@
 # English translations (default)
 
-[_]
 # General
 aborted = "Aborted."
 cached = "(cached)"
@@ -22,7 +21,7 @@ error_no_api_key = "No API key found. Set YAAK_API_KEY, pass --api-key, or add i
 prompt_execute = "Execute?"
 prompt_what_next = "What next?"
 prompt_refine = "Refine your request"
-label_command = "  Command: "
+label_command = "\nCommand: "
 label_thinking = "Thinking "
 choice_execute = "Execute"
 choice_refine = "Refine"

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -1,6 +1,5 @@
 # Spanish translations
 
-[_]
 # General
 aborted = "Cancelado."
 cached = "(en caché)"
@@ -22,7 +21,7 @@ error_no_api_key = "No se encontró clave API. Establece YAAK_API_KEY, usa --api
 prompt_execute = "¿Ejecutar?"
 prompt_what_next = "¿Qué hacer?"
 prompt_refine = "Refinar solicitud"
-label_command = "  Comando: "
+label_command = "\nComando: "
 label_thinking = "Pensando "
 choice_execute = "Ejecutar"
 choice_refine = "Refinar"

--- a/locales/fr.toml
+++ b/locales/fr.toml
@@ -1,6 +1,5 @@
 # French translations
 
-[_]
 # General
 aborted = "Annulé."
 cached = "(en cache)"
@@ -22,7 +21,7 @@ error_no_api_key = "Aucune clé API trouvée. Définissez YAAK_API_KEY, utilisez
 prompt_execute = "Exécuter ?"
 prompt_what_next = "Et maintenant ?"
 prompt_refine = "Affiner la demande"
-label_command = "  Commande : "
+label_command = "\nCommande : "
 label_thinking = "Réflexion "
 choice_execute = "Exécuter"
 choice_refine = "Affiner"

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -1,6 +1,5 @@
 # Japanese translations
 
-[_]
 # General
 aborted = "中止しました。"
 cached = "（キャッシュ）"
@@ -22,7 +21,7 @@ error_no_api_key = "APIキーが見つかりません。YAAK_API_KEY を設定�
 prompt_execute = "実行しますか？"
 prompt_what_next = "次のアクション"
 prompt_refine = "リクエストを修正"
-label_command = "  コマンド："
+label_command = "\nコマンド："
 label_thinking = "考え中 "
 choice_execute = "実行"
 choice_refine = "修正"

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -1,6 +1,5 @@
 # Korean translations
 
-[_]
 # General
 aborted = "취소되었습니다."
 cached = "(캐시됨)"
@@ -22,7 +21,7 @@ error_no_api_key = "API 키를 찾을 수 없습니다. YAAK_API_KEY를 설정�
 prompt_execute = "실행할까요?"
 prompt_what_next = "다음 작업"
 prompt_refine = "요청 수정"
-label_command = "  명령어: "
+label_command = "\n명령어: "
 label_thinking = "생각 중 "
 choice_execute = "실행"
 choice_refine = "수정"

--- a/locales/pt.toml
+++ b/locales/pt.toml
@@ -1,6 +1,5 @@
 # Portuguese (Brazilian) translations
 
-[_]
 # General
 aborted = "Cancelado."
 cached = "(em cache)"
@@ -22,7 +21,7 @@ error_no_api_key = "Nenhuma chave de API encontrada. Defina YAAK_API_KEY, use --
 prompt_execute = "Executar?"
 prompt_what_next = "O que fazer?"
 prompt_refine = "Refinar solicitação"
-label_command = "  Comando: "
+label_command = "\nComando: "
 label_thinking = "Pensando "
 choice_execute = "Executar"
 choice_refine = "Refinar"

--- a/locales/zh.toml
+++ b/locales/zh.toml
@@ -1,6 +1,5 @@
 # Chinese Simplified translations
 
-[_]
 # General
 aborted = "已取消。"
 cached = "（缓存）"
@@ -22,7 +21,7 @@ error_no_api_key = "未找到 API 密钥。请设置 YAAK_API_KEY、使用 --api
 prompt_execute = "执行？"
 prompt_what_next = "下一步？"
 prompt_refine = "优化请求"
-label_command = "  命令："
+label_command = "\n命令："
 label_thinking = "思考中 "
 choice_execute = "执行"
 choice_refine = "优化"


### PR DESCRIPTION
## Summary
- Fix i18n translations showing raw key names (e.g. `label_command`, `prompt_what_next`) instead of translated text by removing invalid `[_]` TOML section headers from all 8 locale files
- Replace leading whitespace in `label_command` with a line break for better formatting
- Bump version to 0.1.3 and update CHANGELOG.md

## Test plan
- [x] Run `cargo run -- list files` and verify translated labels appear (e.g. "Command:", "What next?", "Execute")
- [x] Test with a non-English locale: `cargo run -- -L de list files` and verify German translations render
- [x] Verify `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)