### PR TITLE
Add shell alias wizard step to create y -> yaak shortcut

### DIFF
--- a/locales/de.toml
+++ b/locales/de.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "Anbieter:"
 wizard_label_model = "Modell:"
 wizard_label_api_key = "API-Schlüssel:"
 wizard_success = "Fertig! Probiere: yaak Dateien im aktuellen Verzeichnis auflisten"
+wizard_alias_prompt = "Kurzen Alias erstellen, damit Sie `y` statt `yaak` eingeben können?"
+wizard_alias_already_exists = "Alias y='yaak' existiert bereits in %{path}"
+wizard_alias_added = "Alias hinzugefügt in %{path}"
+wizard_alias_source_hint = "Führen Sie `source %{path}` aus, um den Alias in Ihrer aktuellen Sitzung zu aktivieren."
+wizard_alias_write_error = "Alias konnte nicht geschrieben werden: %{error}"
 wizard_select_language = "Sprache auswählen"
 
 # Explain display labels

--- a/locales/de.toml
+++ b/locales/de.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "Alias y='yaak' existiert bereits in %{path}"
 wizard_alias_added = "Alias hinzugefügt in %{path}"
 wizard_alias_source_hint = "Führen Sie `source %{path}` aus, um den Alias in Ihrer aktuellen Sitzung zu aktivieren."
 wizard_alias_write_error = "Alias konnte nicht geschrieben werden: %{error}"
+wizard_alias_conflict = "`y` ist bereits auf `%{target}` gemappt — dieser Alias wird es überschreiben."
+wizard_alias_overwrite_prompt = "Bestehende Zuordnung überschreiben?"
 wizard_select_language = "Sprache auswählen"
 
 # Explain display labels

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "Alias y='yaak' already exists in %{path}"
 wizard_alias_added = "Alias added to %{path}"
 wizard_alias_source_hint = "Run `source %{path}` to activate the alias in your current session."
 wizard_alias_write_error = "Failed to write alias: %{error}"
+wizard_alias_conflict = "`y` is already mapped to `%{target}` — creating this alias will override it."
+wizard_alias_overwrite_prompt = "Overwrite the existing mapping?"
 wizard_select_language = "Select your language"
 
 # Explain display labels

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "Provider:"
 wizard_label_model = "Model:"
 wizard_label_api_key = "API key:"
 wizard_success = "You're all set! Try: yaak list files in current directory"
+wizard_alias_prompt = "Create a short alias so you can type `y` instead of `yaak`?"
+wizard_alias_already_exists = "Alias y='yaak' already exists in %{path}"
+wizard_alias_added = "Alias added to %{path}"
+wizard_alias_source_hint = "Run `source %{path}` to activate the alias in your current session."
+wizard_alias_write_error = "Failed to write alias: %{error}"
 wizard_select_language = "Select your language"
 
 # Explain display labels

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "Proveedor:"
 wizard_label_model = "Modelo:"
 wizard_label_api_key = "Clave API:"
 wizard_success = "¡Listo! Prueba: yaak listar archivos en el directorio actual"
+wizard_alias_prompt = "¿Crear un alias corto para escribir `y` en lugar de `yaak`?"
+wizard_alias_already_exists = "El alias y='yaak' ya existe en %{path}"
+wizard_alias_added = "Alias añadido en %{path}"
+wizard_alias_source_hint = "Ejecuta `source %{path}` para activar el alias en tu sesión actual."
+wizard_alias_write_error = "No se pudo escribir el alias: %{error}"
 wizard_select_language = "Selecciona tu idioma"
 
 # Explain display labels

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "El alias y='yaak' ya existe en %{path}"
 wizard_alias_added = "Alias añadido en %{path}"
 wizard_alias_source_hint = "Ejecuta `source %{path}` para activar el alias en tu sesión actual."
 wizard_alias_write_error = "No se pudo escribir el alias: %{error}"
+wizard_alias_conflict = "`y` ya está asignado a `%{target}` — crear este alias lo sobrescribirá."
+wizard_alias_overwrite_prompt = "¿Sobrescribir la asignación existente?"
 wizard_select_language = "Selecciona tu idioma"
 
 # Explain display labels

--- a/locales/fr.toml
+++ b/locales/fr.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "Fournisseur :"
 wizard_label_model = "Modèle :"
 wizard_label_api_key = "Clé API :"
 wizard_success = "C'est prêt ! Essayez : yaak lister les fichiers du répertoire courant"
+wizard_alias_prompt = "Créer un alias court pour taper `y` au lieu de `yaak` ?"
+wizard_alias_already_exists = "L'alias y='yaak' existe déjà dans %{path}"
+wizard_alias_added = "Alias ajouté dans %{path}"
+wizard_alias_source_hint = "Exécutez `source %{path}` pour activer l'alias dans votre session actuelle."
+wizard_alias_write_error = "Impossible d'écrire l'alias : %{error}"
 wizard_select_language = "Sélectionnez votre langue"
 
 # Explain display labels

--- a/locales/fr.toml
+++ b/locales/fr.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "L'alias y='yaak' existe déjà dans %{path}"
 wizard_alias_added = "Alias ajouté dans %{path}"
 wizard_alias_source_hint = "Exécutez `source %{path}` pour activer l'alias dans votre session actuelle."
 wizard_alias_write_error = "Impossible d'écrire l'alias : %{error}"
+wizard_alias_conflict = "`y` est déjà associé à `%{target}` — créer cet alias le remplacera."
+wizard_alias_overwrite_prompt = "Remplacer l'association existante ?"
 wizard_select_language = "Sélectionnez votre langue"
 
 # Explain display labels

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "エイリアス y='yaak' は %{path} に既に存
 wizard_alias_added = "エイリアスを %{path} に追加しました"
 wizard_alias_source_hint = "`source %{path}` を実行して、現在のセッションでエイリアスを有効にしてください。"
 wizard_alias_write_error = "エイリアスを書き込めません：%{error}"
+wizard_alias_conflict = "`y` は既に `%{target}` にマッピングされています — このエイリアスを作成すると上書きされます。"
+wizard_alias_overwrite_prompt = "既存のマッピングを上書きしますか？"
 wizard_select_language = "言語を選択"
 
 # Explain display labels

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "プロバイダー："
 wizard_label_model = "モデル："
 wizard_label_api_key = "APIキー："
 wizard_success = "準備完了！試してみてください：yaak カレントディレクトリのファイルを一覧表示"
+wizard_alias_prompt = "`yaak` の代わりに `y` と入力できる短いエイリアスを作成しますか？"
+wizard_alias_already_exists = "エイリアス y='yaak' は %{path} に既に存在します"
+wizard_alias_added = "エイリアスを %{path} に追加しました"
+wizard_alias_source_hint = "`source %{path}` を実行して、現在のセッションでエイリアスを有効にしてください。"
+wizard_alias_write_error = "エイリアスを書き込めません：%{error}"
 wizard_select_language = "言語を選択"
 
 # Explain display labels

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "별칭 y='yaak'가 이미 %{path}에 존재합니
 wizard_alias_added = "별칭이 %{path}에 추가되었습니다"
 wizard_alias_source_hint = "`source %{path}`를 실행하여 현재 세션에서 별칭을 활성화하세요."
 wizard_alias_write_error = "별칭을 저장할 수 없습니다: %{error}"
+wizard_alias_conflict = "`y`가 이미 `%{target}`에 매핑되어 있습니다 — 이 별칭을 만들면 덮어쓰게 됩니다."
+wizard_alias_overwrite_prompt = "기존 매핑을 덮어쓸까요?"
 wizard_select_language = "언어 선택"
 
 # Explain display labels

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "제공자:"
 wizard_label_model = "모델:"
 wizard_label_api_key = "API 키:"
 wizard_success = "준비 완료! 사용해 보세요: yaak 현재 디렉터리의 파일 목록 표시"
+wizard_alias_prompt = "`yaak` 대신 `y`로 입력할 수 있는 단축 별칭을 만들까요?"
+wizard_alias_already_exists = "별칭 y='yaak'가 이미 %{path}에 존재합니다"
+wizard_alias_added = "별칭이 %{path}에 추가되었습니다"
+wizard_alias_source_hint = "`source %{path}`를 실행하여 현재 세션에서 별칭을 활성화하세요."
+wizard_alias_write_error = "별칭을 저장할 수 없습니다: %{error}"
 wizard_select_language = "언어 선택"
 
 # Explain display labels

--- a/locales/pt.toml
+++ b/locales/pt.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "O alias y='yaak' já existe em %{path}"
 wizard_alias_added = "Alias adicionado em %{path}"
 wizard_alias_source_hint = "Execute `source %{path}` para ativar o alias na sua sessão atual."
 wizard_alias_write_error = "Não foi possível gravar o alias: %{error}"
+wizard_alias_conflict = "`y` já está mapeado para `%{target}` — criar este alias irá sobrescrevê-lo."
+wizard_alias_overwrite_prompt = "Sobrescrever o mapeamento existente?"
 wizard_select_language = "Selecione seu idioma"
 
 # Explain display labels

--- a/locales/pt.toml
+++ b/locales/pt.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "Provedor:"
 wizard_label_model = "Modelo:"
 wizard_label_api_key = "Chave API:"
 wizard_success = "Tudo pronto! Experimente: yaak listar arquivos no diretório atual"
+wizard_alias_prompt = "Criar um alias curto para digitar `y` em vez de `yaak`?"
+wizard_alias_already_exists = "O alias y='yaak' já existe em %{path}"
+wizard_alias_added = "Alias adicionado em %{path}"
+wizard_alias_source_hint = "Execute `source %{path}` para ativar o alias na sua sessão atual."
+wizard_alias_write_error = "Não foi possível gravar o alias: %{error}"
 wizard_select_language = "Selecione seu idioma"
 
 # Explain display labels

--- a/locales/zh.toml
+++ b/locales/zh.toml
@@ -63,6 +63,8 @@ wizard_alias_already_exists = "别名 y='yaak' 已存在于 %{path}"
 wizard_alias_added = "别名已添加到 %{path}"
 wizard_alias_source_hint = "运行 `source %{path}` 以在当前会话中激活别名。"
 wizard_alias_write_error = "无法写入别名：%{error}"
+wizard_alias_conflict = "`y` 已映射到 `%{target}` — 创建此别名将覆盖它。"
+wizard_alias_overwrite_prompt = "覆盖现有映射？"
 wizard_select_language = "选择语言"
 
 # Explain display labels

--- a/locales/zh.toml
+++ b/locales/zh.toml
@@ -58,6 +58,11 @@ wizard_label_provider = "提供商："
 wizard_label_model = "模型："
 wizard_label_api_key = "API 密钥："
 wizard_success = "设置完成！试试：yaak 列出当前目录的文件"
+wizard_alias_prompt = "创建一个快捷别名，用 `y` 代替 `yaak`？"
+wizard_alias_already_exists = "别名 y='yaak' 已存在于 %{path}"
+wizard_alias_added = "别名已添加到 %{path}"
+wizard_alias_source_hint = "运行 `source %{path}` 以在当前会话中激活别名。"
+wizard_alias_write_error = "无法写入别名：%{error}"
 wizard_select_language = "选择语言"
 
 # Explain display labels

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -284,15 +284,12 @@ fn offer_shell_alias() {
 
     let (rc_path, alias_line) = match shell_name {
         "zsh" => (home.join(".zshrc"), "alias y='yaak'"),
-        "fish" => (
-            home.join(".config/fish/config.fish"),
-            "alias y 'yaak'",
-        ),
+        "fish" => (home.join(".config/fish/config.fish"), "alias y 'yaak'"),
         // bash and anything else
         _ => (home.join(".bashrc"), "alias y='yaak'"),
     };
 
-    // Check if alias already exists
+    // Check if the exact alias already exists in the rc file
     if rc_path.exists() {
         if let Ok(contents) = std::fs::read_to_string(&rc_path) {
             if contents.contains(alias_line) {
@@ -306,14 +303,31 @@ fn offer_shell_alias() {
         }
     }
 
-    let create_alias = Confirm::new()
-        .with_prompt(t!("wizard_alias_prompt").to_string())
-        .default(true)
-        .interact()
-        .unwrap_or(false);
-
-    if !create_alias {
-        return;
+    // Check if `y` is already mapped to something else
+    let existing_target = detect_existing_y(&shell, &rc_path, shell_name);
+    if let Some(target) = &existing_target {
+        eprintln!(
+            "{} {}",
+            t!("warning_prefix").yellow().bold(),
+            t!("wizard_alias_conflict", target = target.as_str())
+        );
+        let overwrite = Confirm::new()
+            .with_prompt(t!("wizard_alias_overwrite_prompt").to_string())
+            .default(false)
+            .interact()
+            .unwrap_or(false);
+        if !overwrite {
+            return;
+        }
+    } else {
+        let create_alias = Confirm::new()
+            .with_prompt(t!("wizard_alias_prompt").to_string())
+            .default(true)
+            .interact()
+            .unwrap_or(false);
+        if !create_alias {
+            return;
+        }
     }
 
     // Ensure parent directory exists (relevant for fish)
@@ -345,8 +359,7 @@ fn offer_shell_alias() {
             );
             eprintln!(
                 "  {}",
-                t!("wizard_alias_source_hint", path = rc_path.display())
-                    .yellow()
+                t!("wizard_alias_source_hint", path = rc_path.display()).yellow()
             );
         }
         Err(e) => {
@@ -357,4 +370,56 @@ fn offer_shell_alias() {
             );
         }
     }
+}
+
+/// Check whether `y` is already defined as an alias (to something other than yaak)
+/// or exists as a command on the system. Returns the existing target if found.
+fn detect_existing_y(shell_path: &str, rc_path: &PathBuf, shell_name: &str) -> Option<String> {
+    // 1. Check rc file for an existing alias definition for `y`
+    if rc_path.exists() {
+        if let Ok(contents) = std::fs::read_to_string(rc_path) {
+            for line in contents.lines() {
+                let trimmed = line.trim();
+                match shell_name {
+                    "fish" => {
+                        // fish: `alias y 'something'` or `alias y "something"` or `alias y something`
+                        if let Some(rest) = trimmed.strip_prefix("alias y ") {
+                            let value = rest.trim().trim_matches(|c| c == '\'' || c == '"');
+                            if value != "yaak" {
+                                return Some(value.to_string());
+                            }
+                        }
+                    }
+                    _ => {
+                        // bash/zsh: `alias y='something'` or `alias y="something"`
+                        if let Some(rest) = trimmed.strip_prefix("alias y=") {
+                            let value = rest.trim_matches(|c| c == '\'' || c == '"');
+                            if value != "yaak" {
+                                return Some(value.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // 2. Check if `y` exists as a command on PATH (binary, script, etc.)
+    let check_cmd = match shell_name {
+        "fish" => "command -v y",
+        _ => "command -v y",
+    };
+    if let Ok(output) = std::process::Command::new(shell_path)
+        .args(["-c", check_cmd])
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return Some(path);
+            }
+        }
+    }
+
+    None
 }

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,6 +1,7 @@
 use colored::Colorize;
 use dialoguer::{Confirm, Input, Password, Select};
 use rust_i18n::t;
+use std::path::PathBuf;
 
 use crate::config::config_path;
 
@@ -265,4 +266,95 @@ pub fn run_config_wizard() {
     }
     eprintln!();
     eprintln!("{}", t!("wizard_success").green());
+    eprintln!();
+
+    // 5. Offer to create shell alias y -> yaak
+    offer_shell_alias();
+}
+
+/// Detect the user's shell rc file and offer to append `alias y='yaak'`.
+fn offer_shell_alias() {
+    let home = match std::env::var("HOME") {
+        Ok(h) => PathBuf::from(h),
+        Err(_) => return, // no HOME — skip silently
+    };
+
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let shell_name = shell.rsplit('/').next().unwrap_or("");
+
+    let (rc_path, alias_line) = match shell_name {
+        "zsh" => (home.join(".zshrc"), "alias y='yaak'"),
+        "fish" => (
+            home.join(".config/fish/config.fish"),
+            "alias y 'yaak'",
+        ),
+        // bash and anything else
+        _ => (home.join(".bashrc"), "alias y='yaak'"),
+    };
+
+    // Check if alias already exists
+    if rc_path.exists() {
+        if let Ok(contents) = std::fs::read_to_string(&rc_path) {
+            if contents.contains(alias_line) {
+                eprintln!(
+                    "{} {}",
+                    "✓".green().bold(),
+                    t!("wizard_alias_already_exists", path = rc_path.display())
+                );
+                return;
+            }
+        }
+    }
+
+    let create_alias = Confirm::new()
+        .with_prompt(t!("wizard_alias_prompt").to_string())
+        .default(true)
+        .interact()
+        .unwrap_or(false);
+
+    if !create_alias {
+        return;
+    }
+
+    // Ensure parent directory exists (relevant for fish)
+    if let Some(parent) = rc_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    // Append alias line
+    let line = format!("\n# yaak shortcut\n{}\n", alias_line);
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&rc_path)
+    {
+        Ok(mut file) => {
+            use std::io::Write;
+            if let Err(e) = file.write_all(line.as_bytes()) {
+                eprintln!(
+                    "{} {}",
+                    t!("error_prefix").red().bold(),
+                    t!("wizard_alias_write_error", error = e)
+                );
+                return;
+            }
+            eprintln!(
+                "{} {}",
+                "✓".green().bold(),
+                t!("wizard_alias_added", path = rc_path.display())
+            );
+            eprintln!(
+                "  {}",
+                t!("wizard_alias_source_hint", path = rc_path.display())
+                    .yellow()
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "{} {}",
+                t!("error_prefix").red().bold(),
+                t!("wizard_alias_write_error", error = e)
+            );
+        }
+    }
 }


### PR DESCRIPTION
Adds a final step to the onboarding wizard that offers to append
`alias y='yaak'` to the user's shell rc file (.bashrc, .zshrc, or
fish config). Detects the current shell, skips if the alias already
exists, and shows a hint to source the rc file. Includes i18n
translations for all 8 supported languages.

https://claude.ai/code/session_01GDB1ERSagN28ZViTTekdFH