### PR TITLE
Bump v0.1.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.4] — 2026-04-12
+
+### Added
+- AUR, Nix, and Scoop package definitions for broader package manager support
+- Blog generated from markdown sources
+- Shell alias wizard step to create `y` → `yaak` shortcut for faster invocation
+- Badges section to README (crates.io, CI status, license)
+
+---
+
 ## [0.1.3] — 2026-04-09
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"

--- a/packaging/aur/yaak-bin/PKGBUILD
+++ b/packaging/aur/yaak-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hannes Hapke <hannes.hapke@gmail.com>
 pkgname=yaak-bin
 _pkgname=yaak
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc="Translate natural language to bash commands using any OpenAI-compatible LLM (prebuilt binary)"
 arch=('x86_64')

--- a/packaging/aur/yaak/PKGBUILD
+++ b/packaging/aur/yaak/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Hannes Hapke <hannes.hapke@gmail.com>
 pkgname=yaak
-pkgver=0.1.3
+pkgver=0.1.4
 pkgrel=1
 pkgdesc="Translate natural language to bash commands using any OpenAI-compatible LLM"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Summary
- Patch version bump from **0.1.3** → **0.1.4**
- Updated version in `Cargo.toml`, `packaging/aur/yaak/PKGBUILD`, and `packaging/aur/yaak-bin/PKGBUILD`
- Added changelog entry for v0.1.4 covering all changes since last release:
  - AUR, Nix, and Scoop package definitions
  - Blog generated from markdown sources
  - Shell alias wizard step (`y` → `yaak` shortcut)
  - README badges (crates.io, CI status, license)

## Test plan
- [ ] Verify `Cargo.toml` version reads `0.1.4`
- [ ] Verify both AUR PKGBUILD files reference `pkgver=0.1.4`
- [ ] Verify CHANGELOG.md has correct v0.1.4 entry with today's date
- [ ] Confirm `cargo check` passes with the new version

https://claude.ai/code/session_01RK3S24ypShs5XhDhFB1acg