### PR TITLE
Add AUR, Scoop, and Nix badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # yaak — Yet Another AI for the Kommandozeile
 
 [![Crates.io](https://img.shields.io/crates/v/yaak.svg)](https://crates.io/crates/yaak)
-[![Homebrew](https://img.shields.io/badge/homebrew-hanneshapke%2Fyaak-orange)](https://github.com/hanneshapke/homebrew-yaak)
-[![AUR](https://img.shields.io/aur/version/yaak-cli)](https://aur.archlinux.org/packages/yaak-cli)
-[![Scoop](https://img.shields.io/badge/scoop-yaak-blue)](https://github.com/hanneshapke/scoop-yaak)
-[![Nix](https://img.shields.io/badge/nix-flake-5277C3)](https://github.com/hanneshapke/yaak#nix--nixos-flakes)
 [![License](https://img.shields.io/crates/l/yaak.svg)](https://github.com/hanneshapke/yaak/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/hanneshapke/yaak.svg?style=social)](https://github.com/hanneshapke/yaak/stargazers)
+
+[![Homebrew](https://img.shields.io/badge/homebrew-hanneshapke%2Fyaak-orange)](https://github.com/hanneshapke/homebrew-yaak)
+[![AUR](https://img.shields.io/aur/version/yaak-cli)](https://aur.archlinux.org/packages/yaak-cli)
+[![Nix](https://img.shields.io/badge/nix-flake-5277C3)](https://github.com/hanneshapke/yaak#nix--nixos-flakes)
+[![Scoop](https://img.shields.io/badge/scoop-yaak-blue)](https://github.com/hanneshapke/scoop-yaak)
 
 Translate natural language into bash commands using any OpenAI-compatible LLM. Supports 8 languages.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![Crates.io](https://img.shields.io/crates/v/yaak.svg)](https://crates.io/crates/yaak)
 [![Homebrew](https://img.shields.io/badge/homebrew-hanneshapke%2Fyaak-orange)](https://github.com/hanneshapke/homebrew-yaak)
+[![AUR](https://img.shields.io/aur/version/yaak-cli)](https://aur.archlinux.org/packages/yaak-cli)
+[![Scoop](https://img.shields.io/badge/scoop-yaak-blue)](https://github.com/hanneshapke/scoop-yaak)
+[![Nix](https://img.shields.io/badge/nix-flake-5277C3)](https://github.com/hanneshapke/yaak#nix--nixos-flakes)
 [![License](https://img.shields.io/crates/l/yaak.svg)](https://github.com/hanneshapke/yaak/blob/main/LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/hanneshapke/yaak.svg?style=social)](https://github.com/hanneshapke/yaak/stargazers)
 


### PR DESCRIPTION
## Summary
- Add AUR badge (with live version from aur.archlinux.org) linking to the `yaak-cli` package
- Add Scoop badge linking to `hanneshapke/scoop-yaak` bucket repo
- Add Nix flake badge linking to the install section in the README

## Test plan
- [x] Verify badges render correctly on the GitHub README
- [x] Verify badge links point to the correct destinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)