### PR TITLE
Improve sudo/privilege-escalation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ yaak --completions fish > ~/.config/fish/completions/yaak.fish
 
 ### Safety
 
-yaak blocks destructive commands (`rm`, `dd`, `mkfs`, `shred`, etc.) from being executed, including `sudo` variants and piped/chained sequences.
+yaak blocks destructive commands (`rm`, `dd`, `mkfs`, `shred`, etc.) from being executed, including privilege-escalation variants (`sudo`, `doas`, `pkexec` — with flags, `env` wrappers, etc.) and piped/chained sequences. Commands that use privilege escalation without being destructive trigger a separate confirmation prompt warning about elevated privileges.
 
 ## Compatible providers
 

--- a/blog/2026-04-11-10-things-yaak-can-do.md
+++ b/blog/2026-04-11-10-things-yaak-can-do.md
@@ -95,7 +95,7 @@ The CLI prompts, error messages, and all interaction surfaces are localized — 
 
 ## 8. Safety guards for destructive commands
 
-yaak refuses to auto-execute commands containing `rm`, `dd`, `mkfs`, `shred`, and their `sudo` variants. Even with `-y` (auto-execute), destructive commands always require explicit confirmation. You can review every generated command before it runs, every time.
+yaak refuses to auto-execute commands containing `rm`, `dd`, `mkfs`, `shred`, and their privilege-escalation variants (`sudo`, `doas`, `pkexec` — including flags and `env` wrappers). Even with `-y` (auto-execute), destructive commands always require explicit confirmation. Non-destructive commands that use `sudo` or other escalation tools get a separate privilege warning so you always know when a command will run as root. You can review every generated command before it runs, every time.
 
 It's the safety net you didn't know you wanted until the first time it stops a runaway `rm -rf`.
 

--- a/blog/2026-04-11-yaak-vs-the-world.md
+++ b/blog/2026-04-11-yaak-vs-the-world.md
@@ -50,7 +50,7 @@ ShellGPT requires Python, pip, and occasionally a dance with `pipx` on Linux dis
 
 ### Safety by default
 
-yaak blocks destructive commands — `rm`, `dd`, `mkfs`, `shred`, and their `sudo` variants — from being auto-executed. Every command is shown before it runs, and nothing executes without confirmation (unless you pass `-y` when you trust it).
+yaak blocks destructive commands — `rm`, `dd`, `mkfs`, `shred`, and their privilege-escalation variants (`sudo`, `doas`, `pkexec`) — from being auto-executed. Non-destructive commands that require `sudo` get a separate privilege-escalation warning. Every command is shown before it runs, and nothing executes without confirmation (unless you pass `-y` when you trust it).
 
 Copilot CLI has a similar approval flow, but its scope is much wider — it can edit files, run arbitrary scripts, and operate autonomously in "autopilot mode." That power is great for coding tasks, but it's more attack surface than you need for translating English to shell commands.
 

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -518,16 +518,24 @@
       <!-- SAFETY -->
       <section class="doc-section" id="safety">
         <h2>Safe<em>ty</em></h2>
-        <p>yaak blocks destructive commands before execution. The following patterns are detected and rejected, including <code>sudo</code> variants and piped/chained sequences:</p>
+        <p>yaak blocks destructive commands before execution. The following patterns are detected and rejected, including privilege-escalation variants (<code>sudo</code>, <code>doas</code>, <code>pkexec</code> — with flags, <code>env</code> wrappers, etc.) and piped/chained sequences:</p>
         <div class="doc-code">
           rm &nbsp;&bull;&nbsp; rmdir &nbsp;&bull;&nbsp; mkfs &nbsp;&bull;&nbsp; dd &nbsp;&bull;&nbsp; shred &nbsp;&bull;&nbsp; wipefs<br>
           > /dev/ &nbsp;&bull;&nbsp; chmod 000 &nbsp;&bull;&nbsp; :(){ :|:& };:
         </div>
-        <p>If a destructive command is detected, yaak prints a warning and exits without executing.</p>
+        <p>If a destructive command is detected, yaak prints a warning and asks for confirmation before executing.</p>
         <div class="doc-code">
           <span class="t-green">$</span> yaak delete all files in this directory<br>
           <span class="t-dim">  Command:</span> rm -rf ./*<br>
           <span style="color: var(--red-light);">blocked:</span> Destructive command blocked: `rm` is not allowed.
+        </div>
+        <h3>Privilege escalation</h3>
+        <p>Commands using <code>sudo</code>, <code>doas</code>, or <code>pkexec</code> that are not destructive trigger a separate confirmation prompt warning about elevated privileges. This applies even when flags or <code>env</code> wrappers are used (e.g. <code>sudo -u root</code>, <code>sudo env VAR=val</code>).</p>
+        <div class="doc-code">
+          <span class="t-green">$</span> yaak restart nginx<br>
+          <span class="t-dim">  Command:</span> sudo systemctl restart nginx<br>
+          <span style="color: var(--yellow);">warning:</span> ⚠ This command requires elevated privileges (sudo/doas/pkexec)<br>
+          Run with elevated privileges? [y/N]
         </div>
       </section>
 

--- a/locales/de.toml
+++ b/locales/de.toml
@@ -31,6 +31,8 @@ no_history_entries = "Noch keine Verlaufseinträge."
 destructive_blocked = "Destruktiver Befehl blockiert: `%{keyword}` ist nicht erlaubt. Verwenden Sie --force zum Überschreiben."
 destructive_warning = "⚠ Destruktiver Befehl erkannt: `%{keyword}`"
 destructive_confirm = "Sind Sie sicher, dass Sie diesen destruktiven Befehl ausführen möchten?"
+sudo_warning = "⚠ Dieser Befehl erfordert erhöhte Rechte (sudo/doas/pkexec)"
+sudo_confirm = "Mit erhöhten Rechten ausführen?"
 clipboard_copied = "Befehl in Zwischenablage kopiert"
 clipboard_failed = "Kopieren fehlgeschlagen — Befehl wird stattdessen ausgegeben:"
 

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -31,6 +31,8 @@ no_history_entries = "No history entries yet."
 destructive_blocked = "Destructive command blocked: `%{keyword}` is not allowed. Use --force to override."
 destructive_warning = "⚠ Destructive command detected: `%{keyword}`"
 destructive_confirm = "Are you sure you want to run this destructive command?"
+sudo_warning = "⚠ This command requires elevated privileges (sudo/doas/pkexec)"
+sudo_confirm = "Run with elevated privileges?"
 clipboard_copied = "Command copied to clipboard"
 clipboard_failed = "Failed to copy — printing command instead:"
 

--- a/locales/es.toml
+++ b/locales/es.toml
@@ -31,6 +31,8 @@ no_history_entries = "Aún no hay entradas en el historial."
 destructive_blocked = "Comando destructivo bloqueado: `%{keyword}` no está permitido. Use --force para anular."
 destructive_warning = "⚠ Comando destructivo detectado: `%{keyword}`"
 destructive_confirm = "¿Está seguro de que desea ejecutar este comando destructivo?"
+sudo_warning = "⚠ Este comando requiere privilegios elevados (sudo/doas/pkexec)"
+sudo_confirm = "¿Ejecutar con privilegios elevados?"
 clipboard_copied = "Comando copiado al portapapeles"
 clipboard_failed = "Error al copiar — mostrando comando en su lugar:"
 

--- a/locales/fr.toml
+++ b/locales/fr.toml
@@ -31,6 +31,8 @@ no_history_entries = "Aucune entrée dans l'historique."
 destructive_blocked = "Commande destructive bloquée : `%{keyword}` n'est pas autorisé. Utilisez --force pour forcer."
 destructive_warning = "⚠ Commande destructive détectée : `%{keyword}`"
 destructive_confirm = "Êtes-vous sûr de vouloir exécuter cette commande destructive ?"
+sudo_warning = "⚠ Cette commande nécessite des privilèges élevés (sudo/doas/pkexec)"
+sudo_confirm = "Exécuter avec des privilèges élevés ?"
 clipboard_copied = "Commande copiée dans le presse-papiers"
 clipboard_failed = "Échec de la copie — affichage de la commande :"
 

--- a/locales/ja.toml
+++ b/locales/ja.toml
@@ -31,6 +31,8 @@ no_history_entries = "履歴がまだありません。"
 destructive_blocked = "危険なコマンドをブロックしました：`%{keyword}` は許可されていません。--force を使用して上書きできます。"
 destructive_warning = "⚠ 危険なコマンドが検出されました：`%{keyword}`"
 destructive_confirm = "この危険なコマンドを実行してもよろしいですか？"
+sudo_warning = "⚠ このコマンドには昇格された権限が必要です (sudo/doas/pkexec)"
+sudo_confirm = "昇格された権限で実行しますか？"
 clipboard_copied = "コマンドをクリップボードにコピーしました"
 clipboard_failed = "コピーに失敗しました——代わりにコマンドを表示します："
 

--- a/locales/ko.toml
+++ b/locales/ko.toml
@@ -31,6 +31,8 @@ no_history_entries = "아직 기록이 없습니다."
 destructive_blocked = "위험한 명령어가 차단되었습니다: `%{keyword}`은(는) 허용되지 않습니다. --force를 사용하여 재정의할 수 있습니다."
 destructive_warning = "⚠ 위험한 명령어가 감지되었습니다: `%{keyword}`"
 destructive_confirm = "이 위험한 명령어를 실행하시겠습니까?"
+sudo_warning = "⚠ 이 명령은 관리자 권한이 필요합니다 (sudo/doas/pkexec)"
+sudo_confirm = "관리자 권한으로 실행하시겠습니까?"
 clipboard_copied = "명령어가 클립보드에 복사되었습니다"
 clipboard_failed = "복사 실패 — 대신 명령어를 출력합니다:"
 

--- a/locales/pt.toml
+++ b/locales/pt.toml
@@ -31,6 +31,8 @@ no_history_entries = "Nenhuma entrada no histórico ainda."
 destructive_blocked = "Comando destrutivo bloqueado: `%{keyword}` não é permitido. Use --force para substituir."
 destructive_warning = "⚠ Comando destrutivo detectado: `%{keyword}`"
 destructive_confirm = "Tem certeza de que deseja executar este comando destrutivo?"
+sudo_warning = "⚠ Este comando requer privilégios elevados (sudo/doas/pkexec)"
+sudo_confirm = "Executar com privilégios elevados?"
 clipboard_copied = "Comando copiado para a área de transferência"
 clipboard_failed = "Falha ao copiar — exibindo o comando:"
 

--- a/locales/zh.toml
+++ b/locales/zh.toml
@@ -31,6 +31,8 @@ no_history_entries = "暂无历史记录。"
 destructive_blocked = "危险命令已阻止：不允许使用 `%{keyword}`。使用 --force 强制执行。"
 destructive_warning = "⚠ 检测到危险命令：`%{keyword}`"
 destructive_confirm = "您确定要运行此危险命令吗？"
+sudo_warning = "⚠ 此命令需要提升权限 (sudo/doas/pkexec)"
+sudo_confirm = "以提升的权限运行？"
 clipboard_copied = "命令已复制到剪贴板"
 clipboard_failed = "复制失败——改为输出命令："
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -36,28 +36,105 @@ const DESTRUCTIVE_COMMANDS: &[&str] = &[
     "wipefs ",
 ];
 
+/// Privilege escalation prefixes to detect.
+const ESCALATION_COMMANDS: &[&str] = &["sudo", "doas", "pkexec"];
+
+/// sudo flags that consume the next token as a value argument.
+const SUDO_FLAGS_WITH_VALUE: &[&str] = &[
+    "-u", "--user", "-g", "--group", "-C", "--close-from", "-D", "--chdir", "-R", "--chroot",
+    "-T", "--command-timeout", "-h", "--host", "-p", "--prompt", "-r", "--role", "-t", "--type",
+];
+
+/// Strips privilege-escalation prefixes (sudo, doas, pkexec) and their flags
+/// to reveal the underlying command. Handles patterns like:
+///   sudo -E rm -rf /
+///   sudo -u root env VAR=val dd ...
+///   doas rm -rf /
+fn strip_escalation_prefix(s: &str) -> &str {
+    let s = s.trim();
+    for &prefix in ESCALATION_COMMANDS {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            // Must be followed by whitespace (not e.g. "sudoku")
+            if !rest.starts_with(|c: char| c.is_whitespace()) {
+                continue;
+            }
+            let mut remaining = rest.trim_start();
+            // Skip flags and their value arguments
+            while remaining.starts_with('-') {
+                let token_end = remaining
+                    .find(char::is_whitespace)
+                    .unwrap_or(remaining.len());
+                let flag = &remaining[..token_end];
+                // Advance past this flag token
+                if token_end >= remaining.len() {
+                    return remaining; // flag with no following command
+                }
+                remaining = remaining[token_end..].trim_start();
+                // If this flag takes a value, skip the next token too
+                if SUDO_FLAGS_WITH_VALUE.contains(&flag) && !remaining.is_empty() {
+                    if let Some(pos) = remaining.find(char::is_whitespace) {
+                        remaining = remaining[pos..].trim_start();
+                    } else {
+                        return ""; // value was the last token, no command left
+                    }
+                }
+            }
+            // Skip `env` wrapper if present
+            if let Some(after_env) = remaining.strip_prefix("env") {
+                if after_env.starts_with(|c: char| c.is_whitespace()) {
+                    remaining = after_env.trim_start();
+                    // Skip VAR=val pairs
+                    while let Some(eq_pos) = remaining.find('=') {
+                        // Make sure the '=' is part of a VAR=val token (no space before '=')
+                        let before_eq = &remaining[..eq_pos];
+                        if before_eq.contains(char::is_whitespace) {
+                            break;
+                        }
+                        if let Some(pos) = remaining.find(char::is_whitespace) {
+                            remaining = remaining[pos..].trim_start();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+            return remaining;
+        }
+    }
+    s
+}
+
 /// Returns `Some(keyword)` if the command contains a destructive operation.
 pub fn detect_destructive(command: &str) -> Option<&'static str> {
     // Normalise: check each segment separated by && ; | ||
     for segment in command.split(['&', ';', '|']) {
         let trimmed = segment.trim().trim_start_matches('!');
         let trimmed = trimmed.trim();
+        // Strip any privilege escalation prefix to get the underlying command
+        let effective = strip_escalation_prefix(trimmed);
         for &pattern in DESTRUCTIVE_COMMANDS {
-            if trimmed.starts_with(pattern) || trimmed == pattern.trim() {
+            if effective.starts_with(pattern) || effective == pattern.trim() {
                 return Some(pattern.trim());
-            }
-        }
-        // Also catch "sudo rm ..." etc.
-        if let Some(after_sudo) = trimmed.strip_prefix("sudo ") {
-            let after_sudo = after_sudo.trim();
-            for &pattern in DESTRUCTIVE_COMMANDS {
-                if after_sudo.starts_with(pattern) || after_sudo == pattern.trim() {
-                    return Some(pattern.trim());
-                }
             }
         }
     }
     None
+}
+
+/// Returns `true` if the command contains a privilege-escalation prefix
+/// (sudo, doas, pkexec) in any segment.
+pub fn requires_privilege_escalation(command: &str) -> bool {
+    for segment in command.split(['&', ';', '|']) {
+        let trimmed = segment.trim().trim_start_matches('!').trim();
+        for &prefix in ESCALATION_COMMANDS {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                if rest.is_empty() || rest.starts_with(char::is_whitespace) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 #[cfg(test)]
@@ -76,9 +153,30 @@ mod tests {
     }
 
     #[test]
+    fn blocks_sudo_with_flags() {
+        assert!(detect_destructive("sudo -E rm -rf /").is_some());
+        assert!(detect_destructive("sudo -u root rm -rf /").is_some());
+        assert!(detect_destructive("sudo --preserve-env rm file").is_some());
+    }
+
+    #[test]
+    fn blocks_sudo_env_wrapper() {
+        assert!(detect_destructive("sudo env PATH=/usr/bin dd if=/dev/zero of=/dev/sda").is_some());
+        assert!(detect_destructive("sudo -E env VAR=val rm -rf /tmp").is_some());
+    }
+
+    #[test]
+    fn blocks_doas_and_pkexec() {
+        assert!(detect_destructive("doas rm -rf /").is_some());
+        assert!(detect_destructive("pkexec rm -rf /").is_some());
+        assert!(detect_destructive("doas dd if=/dev/zero of=/dev/sda").is_some());
+    }
+
+    #[test]
     fn blocks_rm_in_chain() {
         assert!(detect_destructive("echo hello && rm -rf /tmp").is_some());
         assert!(detect_destructive("ls; rm foo").is_some());
+        assert!(detect_destructive("ls; sudo rm foo").is_some());
     }
 
     #[test]
@@ -94,6 +192,23 @@ mod tests {
         assert!(detect_destructive("cat file.txt").is_none());
         assert!(detect_destructive("grep -r pattern .").is_none());
         assert!(detect_destructive("echo remove").is_none());
+        // "sudoku" should not match "sudo"
+        assert!(detect_destructive("sudoku").is_none());
+    }
+
+    #[test]
+    fn detects_privilege_escalation() {
+        assert!(requires_privilege_escalation("sudo apt install foo"));
+        assert!(requires_privilege_escalation("doas systemctl restart nginx"));
+        assert!(requires_privilege_escalation("pkexec visudo"));
+        assert!(requires_privilege_escalation("echo hello && sudo service restart"));
+    }
+
+    #[test]
+    fn no_privilege_escalation_for_normal_commands() {
+        assert!(!requires_privilege_escalation("ls -la"));
+        assert!(!requires_privilege_escalation("apt list --installed"));
+        assert!(!requires_privilege_escalation("sudoku")); // not sudo
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -41,8 +41,26 @@ const ESCALATION_COMMANDS: &[&str] = &["sudo", "doas", "pkexec"];
 
 /// sudo flags that consume the next token as a value argument.
 const SUDO_FLAGS_WITH_VALUE: &[&str] = &[
-    "-u", "--user", "-g", "--group", "-C", "--close-from", "-D", "--chdir", "-R", "--chroot",
-    "-T", "--command-timeout", "-h", "--host", "-p", "--prompt", "-r", "--role", "-t", "--type",
+    "-u",
+    "--user",
+    "-g",
+    "--group",
+    "-C",
+    "--close-from",
+    "-D",
+    "--chdir",
+    "-R",
+    "--chroot",
+    "-T",
+    "--command-timeout",
+    "-h",
+    "--host",
+    "-p",
+    "--prompt",
+    "-r",
+    "--role",
+    "-t",
+    "--type",
 ];
 
 /// Strips privilege-escalation prefixes (sudo, doas, pkexec) and their flags
@@ -199,9 +217,13 @@ mod tests {
     #[test]
     fn detects_privilege_escalation() {
         assert!(requires_privilege_escalation("sudo apt install foo"));
-        assert!(requires_privilege_escalation("doas systemctl restart nginx"));
+        assert!(requires_privilege_escalation(
+            "doas systemctl restart nginx"
+        ));
         assert!(requires_privilege_escalation("pkexec visudo"));
-        assert!(requires_privilege_escalation("echo hello && sudo service restart"));
+        assert!(requires_privilege_escalation(
+            "echo hello && sudo service restart"
+        ));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use api::{
 use clap::{CommandFactory, Parser};
 use clap_complete::{generate, Shell};
 use colored::Colorize;
-use command::{detect_destructive, extract_command};
+use command::{detect_destructive, extract_command, requires_privilege_escalation};
 use config::{load_config, resolve};
 use dialoguer::{Confirm, Input, Select};
 use explain::render_explanation;
@@ -319,7 +319,11 @@ fn main() {
              No explanation, no markdown fences, no commentary — just the raw command. \
              Only use flags and tools available on {}. \
              If multiple commands are needed, join them with && or ;. \
-             Use common, portable tools when possible.{}",
+             Use common, portable tools when possible. \
+             Only prefix a command with sudo when the operation genuinely requires root privileges \
+             (e.g. package installation, systemd service management, binding privileged ports). \
+             Never use sudo for file operations in the user's home directory or for commands that \
+             do not require elevated privileges.{}",
             shell_name, os_name, cwd, os_name, lang_hint
         )
     };
@@ -532,6 +536,29 @@ fn main() {
                 let confirmed = Confirm::new()
                     .with_prompt(t!("destructive_confirm").to_string())
                     .default(false)
+                    .interact()
+                    .unwrap_or(false);
+                if !confirmed {
+                    eprintln!("{}", t!("aborted").dimmed());
+                    std::process::exit(0);
+                }
+            }
+        }
+
+        // --- Privilege escalation check ---
+        // Always warn and confirm for sudo/doas/pkexec, even with -y
+        if requires_privilege_escalation(&command) && detect_destructive(&command).is_none() {
+            eprintln!(
+                "{} {}",
+                t!("warning_prefix").yellow().bold(),
+                t!("sudo_warning")
+            );
+            if args.yes {
+                // Even with -y, show the warning (but don't block)
+            } else {
+                let confirmed = Confirm::new()
+                    .with_prompt(t!("sudo_confirm").to_string())
+                    .default(true)
                     .interact()
                     .unwrap_or(false);
                 if !confirmed {


### PR DESCRIPTION
## Summary
- **Hardened destructive-command detection**: strips `sudo`, `doas`, `pkexec` prefixes including flags (`-u root`, `-E`, `--preserve-env`) and `env VAR=val` wrappers before checking for destructive patterns like `rm`, `dd`, `mkfs`, etc.
- **Separate privilege-escalation confirmation**: non-destructive commands using `sudo`/`doas`/`pkexec` now trigger a dedicated warning and confirmation prompt, so users always know when a command will run with elevated privileges.
- **Smarter LLM prompt**: instead of "never use sudo", the system prompt now allows `sudo` when genuinely needed (package install, systemd, privileged ports) while discouraging unnecessary escalation.
- **i18n**: added `sudo_warning` and `sudo_confirm` keys in all 8 locales.
- **Docs updated**: README, landing page docs, and blog posts reflect the new behavior.

## Test plan
- [x] All 67 existing + new unit tests pass (`cargo test`)
- [ ] Manual test: `yaak install htop` → should generate `sudo apt install htop` (on Linux) and show privilege escalation warning
- [ ] Manual test: `yaak delete all files` → should still block as destructive
- [ ] Manual test: `sudo -u root rm -rf /` detected as destructive (new coverage)
- [ ] Manual test: `doas rm -rf /` detected as destructive (new coverage)
- [ ] Verify `-y` flag shows sudo warning but doesn't block

🤖 Generated with [Claude Code](https://claude.com/claude-code)