### PR TITLE
Automate CLI version injection into landing page HTML

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "Cargo.toml"
       - "CHANGELOG.md"
       - "blog/**"
       - "demos/output/**"
@@ -11,6 +12,7 @@ on:
       - "scripts/build_changelog.py"
       - "scripts/build_blog.py"
       - "scripts/copy_assets.py"
+      - "scripts/inject_version.py"
       - ".github/workflows/pages.yml"
   release:
     types: [published]
@@ -43,6 +45,9 @@ jobs:
 
       - name: Copy static assets
         run: python scripts/copy_assets.py
+
+      - name: Inject CLI version
+        run: python scripts/inject_version.py
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/landing/docs.html
+++ b/landing/docs.html
@@ -262,7 +262,7 @@
         <h1 class="page-title">Docu<em>mentation</em></h1>
       </div>
       <div class="page-meta">
-        CLI version: 0.0.12<br>
+        CLI version: {{CLI_VERSION}}<br>
         License: Apache-2.0<br>
         <a href="examples.html" style="color:var(--red);text-decoration:none">See examples &rarr;</a>
       </div>

--- a/scripts/inject_version.py
+++ b/scripts/inject_version.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Inject the CLI version from Cargo.toml into landing page HTML files.
+
+Replaces all occurrences of {{CLI_VERSION}} with the version string
+from the workspace Cargo.toml.
+"""
+
+import re
+from pathlib import Path
+
+
+def get_cargo_version(cargo_toml: Path) -> str:
+    """Extract the version string from Cargo.toml."""
+    text = cargo_toml.read_text()
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not m:
+        raise ValueError(f"Could not find version in {cargo_toml}")
+    return m.group(1)
+
+
+def main():
+    repo_root = Path(__file__).resolve().parent.parent
+    version = get_cargo_version(repo_root / "Cargo.toml")
+
+    landing_dir = repo_root / "landing"
+    count = 0
+    for html_file in landing_dir.glob("*.html"):
+        content = html_file.read_text()
+        if "{{CLI_VERSION}}" in content:
+            html_file.write_text(content.replace("{{CLI_VERSION}}", version))
+            count += 1
+            print(f"  Injected v{version} into {html_file.name}")
+
+    if count == 0:
+        print("  No {{CLI_VERSION}} placeholders found")
+    else:
+        print(f"Injected version {version} into {count} file(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
This PR automates the process of injecting the CLI version from `Cargo.toml` into landing page HTML files, replacing hardcoded version strings with a template variable that gets populated during the build process.

## Key Changes
- **New script**: Added `scripts/inject_version.py` that:
  - Extracts the version string from the workspace `Cargo.toml`
  - Replaces all `{{CLI_VERSION}}` placeholders in HTML files within the `landing/` directory
  - Provides clear console output indicating which files were updated
  
- **Updated workflow**: Modified `.github/workflows/pages.yml` to:
  - Add `Cargo.toml` and `scripts/inject_version.py` to the trigger paths
  - Execute the version injection script as part of the Pages build pipeline (after asset copying)
  
- **Updated landing page**: Changed `landing/docs.html` to use `{{CLI_VERSION}}` placeholder instead of hardcoded version `0.0.12`

## Implementation Details
- The version extraction uses regex to parse the `version` field from `Cargo.toml`, ensuring the build always uses the authoritative version source
- The script gracefully handles cases where no placeholders are found
- The injection step runs after other build steps but before artifact upload, ensuring the final published pages contain the correct version

https://claude.ai/code/session_01TEEnm7NUxuNrsETAXWJps4