### PR TITLE
Bump v0.1.5 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to yaak will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] — 2026-06-21
+
+### Changed
+- Hardened destructive-command detection — `sudo`, `doas`, and `pkexec` prefixes (including flags like `-u root`, `-E`, `--preserve-env`) and `env VAR=val` wrappers are now stripped before matching destructive patterns (`rm`, `dd`, `mkfs`, …)
+- Privilege-escalation commands (`sudo`/`doas`/`pkexec`) now trigger a dedicated warning and confirmation prompt; the system prompt allows `sudo` when genuinely needed (package installs, systemd, privileged ports) instead of forbidding it outright
+- Updated the default Gemma model reference in the setup wizard from `gemma3:4b` to `gemma4:e2b`
+
+### Added
+- `sudo_warning` and `sudo_confirm` translations across all 8 locales
+- Examples page and recorded VHS demos on the landing site
+
+---
+
 ## [0.1.4] — 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,7 +2342,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yaak"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yaak"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Translate natural language to bash commands using an OpenAI-compatible LLM"
 license = "Apache-2.0"

--- a/packaging/aur/yaak-cli-bin/PKGBUILD
+++ b/packaging/aur/yaak-cli-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hannes Hapke <hannes.hapke@gmail.com>
 pkgname=yaak-cli-bin
 _pkgname=yaak
-pkgver=0.1.4
+pkgver=0.1.5
 pkgrel=1
 pkgdesc="Translate natural language to bash commands using any OpenAI-compatible LLM (prebuilt binary)"
 arch=('x86_64')

--- a/packaging/aur/yaak-cli/PKGBUILD
+++ b/packaging/aur/yaak-cli/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Hannes Hapke <hannes.hapke@gmail.com>
 pkgname=yaak-cli
 _pkgname=yaak
-pkgver=0.1.4
+pkgver=0.1.5
 pkgrel=1
 pkgdesc="Translate natural language to bash commands using any OpenAI-compatible LLM"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
## Summary
Patch release **0.1.4 → 0.1.5**.

- Bumped version in `Cargo.toml`, `packaging/aur/yaak-cli/PKGBUILD`, and `packaging/aur/yaak-cli-bin/PKGBUILD`
- Regenerated `Cargo.lock` — this also **fixes long-standing lockfile drift**: the committed `Cargo.lock` still pinned `yaak` at `0.1.3` even after the 0.1.4 release. It's corrected to `0.1.5` here.
- Added the `v0.1.5` CHANGELOG entry covering everything since `v0.1.4`

## Changelog (v0.1.5)
### Changed
- Hardened destructive-command detection — `sudo`/`doas`/`pkexec` prefixes (incl. flags) and `env VAR=val` wrappers are stripped before matching `rm`/`dd`/`mkfs`/… (#97)
- Dedicated privilege-escalation warning + confirmation prompt; system prompt now allows `sudo` when genuinely needed (#97)
- Default Gemma model in the setup wizard: `gemma3:4b` → `gemma4:e2b` (#102)

### Added
- `sudo_warning` / `sudo_confirm` translations in all 8 locales (#97)
- Examples page and recorded VHS demos on the landing site

## Releasing
Merge this, then tag `v0.1.5` on `main` — CI publishes to crates.io, builds binaries, creates the GitHub release, and updates Homebrew/AUR/Scoop/Nix.

## Test plan
- [x] `cargo check` passes with version `0.1.5`
- [x] `Cargo.toml`, both PKGBUILDs, and `Cargo.lock` all read `0.1.5`
- [x] CHANGELOG has the `0.1.5` entry dated 2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)