### PR TITLE
Fix inconsistent assertion

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -346,7 +346,7 @@ mod tests {
         let score = bm25_score(&doc, &query, avg_dl, 1, &df);
         assert!(
             score >= BM25_THRESHOLD,
-            "near-exact match should exceed threshold: {}",
+            "near-exact match should meet or exceed threshold: {}",
             score
         );
     }


### PR DESCRIPTION
For this assertion, "exceed" means `>`, which inaccurately indicate score should > BM25_THRESHOLD, which is inconsistent with assertion's predicate. So it should be changed into "meet or exceed" to be more accurate.
```rust
        assert!(
            score >= BM25_THRESHOLD,
            "near-exact match should exceed threshold: {}",
            score
        );
```